### PR TITLE
Enable managed-key conformance tests

### DIFF
--- a/tests/Sigstore.Tests/Conformance/ConformanceTests.cs
+++ b/tests/Sigstore.Tests/Conformance/ConformanceTests.cs
@@ -22,9 +22,6 @@ public class ConformanceTests
         foreach (var testDir in Directory.GetDirectories(AssetsDir).OrderBy(d => d))
         {
             var name = Path.GetFileName(testDir);
-            // Key-based verification not yet implemented — skip test cases with key.pub
-            if (File.Exists(Path.Combine(testDir, "key.pub")))
-                continue;
             yield return new object[] { name };
         }
     }
@@ -64,6 +61,18 @@ public class ConformanceTests
 
         var verifier = new SigstoreVerifier(trustRootProvider);
         var policy = new VerificationPolicy();
+
+        // Load public key for managed-key verification
+        var keyPubPath = Path.Combine(testDir, "key.pub");
+        if (File.Exists(keyPubPath))
+        {
+            var pem = await File.ReadAllTextAsync(keyPubPath);
+            var base64 = pem
+                .Replace("-----BEGIN PUBLIC KEY-----", "")
+                .Replace("-----END PUBLIC KEY-----", "")
+                .Replace("\n", "").Replace("\r", "").Trim();
+            policy.PublicKey = Convert.FromBase64String(base64);
+        }
 
         using var artifactStream = File.OpenRead(artifactPath);
         var (success, result) = await verifier.TryVerifyAsync(artifactStream, bundle, policy);


### PR DESCRIPTION
## Summary

Remove the skip for managed-key conformance test cases and add public key loading logic so these tests actually run.

## Changes

- **Removed** the `key.pub` skip in `ConformanceTests.cs` that was preventing 3 managed-key test cases from running
- **Added** PEM→DER public key loading to set `VerificationPolicy.PublicKey` when a `key.pub` file exists in the test directory

## Test Results

All 64 conformance tests now pass (previously ~61 with the managed-key tests skipped):
- `managed-key-happy-path` ✅
- `managed-key-and-trusted-root` ✅
- `managed-key-no-key_fail` ✅ (was already running)
- `managed-key-wrong-key_fail` ✅

## Context

The managed-key verification path (`SigstoreVerifier.VerifyWithPublicKey()`) and the conformance CLI `--key` option were already fully implemented. Only the unit-level conformance tests were skipping these cases.

For comparison, sigstore-go still has these as xfails ([sigstore/sigstore-go#561](https://github.com/sigstore/sigstore-go/issues/561)).