### PR TITLE
fix: parse SAN from ASN.1 bytes instead of platform-dependent Format()

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure conformance test assets are checked out with exact byte content.
+# Line-ending conversion would change file hashes and break digest verification.
+tests/sigstore-conformance/** binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # Ensure conformance test assets are checked out with exact byte content.
 # Line-ending conversion would change file hashes and break digest verification.
-tests/sigstore-conformance/** binary
+tests/sigstore-conformance/test/assets/** binary
+samples/data/** binary

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -22,7 +22,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     permissions:
       contents: read
       checks: write
@@ -45,17 +49,13 @@ jobs:
         run: dotnet build Sigstore.slnx --no-restore
 
       - name: Test
-        run: |
-          dotnet test Sigstore.slnx \
-            --no-build \
-            --logger "trx;LogFileName=test-results.trx" \
-            --results-directory ./TestResults
+        run: dotnet test Sigstore.slnx --no-build --logger "trx;LogFileName=test-results.trx" --results-directory ./TestResults
 
       - name: Publish test results
         uses: dorny/test-reporter@v1
         if: success() || failure()
         with:
-          name: Test Results
+          name: Test Results (${{ matrix.os }})
           path: ./TestResults/*.trx
           reporter: dotnet-trx
 
@@ -63,7 +63,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
-          name: test-results
+          name: test-results-${{ matrix.os }}
           path: ./TestResults/
 
   conformance-production:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -32,6 +32,10 @@ jobs:
       checks: write
 
     steps:
+      - name: Disable CRLF conversion
+        if: runner.os == 'Windows'
+        run: git config --global core.autocrlf false
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/src/Sigstore/Verification/ICertificateValidator.cs
+++ b/src/Sigstore/Verification/ICertificateValidator.cs
@@ -96,49 +96,8 @@ internal class DefaultSigningCertificateValidator : ISigningCertificateValidator
             }
         }
 
-        // Extract SAN from the leaf certificate
-        string? san = null;
-        foreach (var ext in leafCertificate.Extensions)
-        {
-            if (ext.Oid?.Value == "2.5.29.17") // Subject Alternative Name
-            {
-                // Parse the SAN extension formatted string
-                var formatted = ext.Format(false);
-                // Try to extract email, URI, or DNS from the formatted string
-                // Format varies by platform but typically: "RFC822 Name=user@example.com" or "email:user@example.com"
-                // or "URI:https://..." or "DNS Name=host"
-                foreach (var part in formatted.Split(',', StringSplitOptions.TrimEntries))
-                {
-                    if (part.Contains("RFC822", StringComparison.OrdinalIgnoreCase) ||
-                        part.Contains("email", StringComparison.OrdinalIgnoreCase))
-                    {
-                        san = part.Split('=', ':').Last().Trim();
-                        break;
-                    }
-                    if (part.Contains("URI", StringComparison.OrdinalIgnoreCase))
-                    {
-                        // URI might be formatted as "URI:https://..." or "Uniform Resource Identifier=https://..."
-                        var idx = part.IndexOf("URI:", StringComparison.OrdinalIgnoreCase);
-                        if (idx >= 0)
-                            san = part.Substring(idx + 4).Trim();
-                        else
-                            san = part.Split('=').Last().Trim();
-                        break;
-                    }
-                }
-                if (san == null)
-                {
-                    // Fall back to DNS names
-                    var sanExt = (X509SubjectAlternativeNameExtension)ext;
-                    foreach (var dns in sanExt.EnumerateDnsNames())
-                    {
-                        san = dns;
-                        break;
-                    }
-                }
-                break;
-            }
-        }
+        // Extract SAN from the leaf certificate using platform-independent ASN.1 parsing
+        var san = SanParser.ExtractSan(leafCertificate);
 
         return new SigningCertificateValidationResult
         {

--- a/src/Sigstore/Verification/SanParser.cs
+++ b/src/Sigstore/Verification/SanParser.cs
@@ -1,0 +1,75 @@
+using System.Formats.Asn1;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Sigstore;
+
+/// <summary>
+/// Parses Subject Alternative Name (SAN) values from X.509 certificates using
+/// raw ASN.1 decoding, avoiding the platform-dependent <c>X509Extension.Format()</c> method.
+/// </summary>
+internal static class SanParser
+{
+    private const string SubjectAlternativeNameOid = "2.5.29.17";
+
+    // ASN.1 context-specific tags for GeneralName (RFC 5280 §4.2.1.6)
+    private static readonly Asn1Tag Rfc822NameTag = new(TagClass.ContextSpecific, 1); // email
+    private static readonly Asn1Tag DnsNameTag = new(TagClass.ContextSpecific, 2);
+    private static readonly Asn1Tag UniformResourceIdentifierTag = new(TagClass.ContextSpecific, 6); // URI
+
+    /// <summary>
+    /// Extracts the most relevant SAN value from a certificate.
+    /// Priority: email (rfc822Name) → URI (uniformResourceIdentifier) → DNS (dNSName).
+    /// </summary>
+    /// <returns>The SAN string, or <c>null</c> if no supported SAN type is found.</returns>
+    internal static string? ExtractSan(X509Certificate2 cert)
+    {
+        foreach (var ext in cert.Extensions)
+        {
+            if (ext.Oid?.Value != SubjectAlternativeNameOid)
+                continue;
+
+            return ParseSanExtension(ext.RawData);
+        }
+
+        return null;
+    }
+
+    private static string? ParseSanExtension(byte[] rawData)
+    {
+        string? email = null;
+        string? uri = null;
+        string? dns = null;
+
+        var reader = new AsnReader(rawData, AsnEncodingRules.DER);
+        var sequence = reader.ReadSequence();
+
+        while (sequence.HasData)
+        {
+            var tag = sequence.PeekTag();
+
+            if (tag == Rfc822NameTag)
+            {
+                var value = sequence.ReadCharacterString(UniversalTagNumber.IA5String, Rfc822NameTag);
+                email ??= value;
+            }
+            else if (tag == UniformResourceIdentifierTag)
+            {
+                var value = sequence.ReadCharacterString(UniversalTagNumber.IA5String, UniformResourceIdentifierTag);
+                uri ??= value;
+            }
+            else if (tag == DnsNameTag)
+            {
+                var value = sequence.ReadCharacterString(UniversalTagNumber.IA5String, DnsNameTag);
+                dns ??= value;
+            }
+            else
+            {
+                // Skip unsupported GeneralName types (otherName, x400Address, directoryName, etc.)
+                sequence.ReadEncodedValue();
+            }
+        }
+
+        // Priority: email → URI → DNS
+        return email ?? uri ?? dns;
+    }
+}

--- a/src/Sigstore/Verification/SigstoreVerifier.cs
+++ b/src/Sigstore/Verification/SigstoreVerifier.cs
@@ -949,34 +949,7 @@ public sealed class SigstoreVerifier
 
     private static string? ExtractSan(X509Certificate2 cert)
     {
-        foreach (var ext in cert.Extensions)
-        {
-            if (ext.Oid?.Value != "2.5.29.17")
-                continue;
-
-            var formatted = ext.Format(false);
-            foreach (var part in formatted.Split(',', StringSplitOptions.TrimEntries))
-            {
-                if (part.Contains("RFC822", StringComparison.OrdinalIgnoreCase) ||
-                    part.Contains("email", StringComparison.OrdinalIgnoreCase))
-                {
-                    return part.Split('=', ':').Last().Trim();
-                }
-                if (part.Contains("URI", StringComparison.OrdinalIgnoreCase))
-                {
-                    var idx = part.IndexOf("URI:", StringComparison.OrdinalIgnoreCase);
-                    if (idx >= 0)
-                        return part.Substring(idx + 4).Trim();
-                    return part.Split('=').Last().Trim();
-                }
-            }
-
-            // Fall back to DNS names
-            var sanExt = (X509SubjectAlternativeNameExtension)ext;
-            foreach (var dns in sanExt.EnumerateDnsNames())
-                return dns;
-        }
-        return null;
+        return SanParser.ExtractSan(cert);
     }
 
     private static string? ExtractOidcIssuer(X509Certificate2 cert)

--- a/tests/Sigstore.Tests/Verification/SanParserTests.cs
+++ b/tests/Sigstore.Tests/Verification/SanParserTests.cs
@@ -1,0 +1,210 @@
+using System.Formats.Asn1;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Sigstore.Tests.Verification;
+
+public class SanParserTests
+{
+    [Fact]
+    public void ExtractSan_WithUriSan_ReturnsUri()
+    {
+        using var cert = CreateCertWithUri("https://github.com/myorg/myrepo/.github/workflows/ci.yml@refs/heads/main");
+
+        var san = SanParser.ExtractSan(cert);
+
+        Assert.Equal("https://github.com/myorg/myrepo/.github/workflows/ci.yml@refs/heads/main", san);
+    }
+
+    [Fact]
+    public void ExtractSan_WithEmailSan_ReturnsEmail()
+    {
+        using var cert = CreateCertWithEmail("user@example.com");
+
+        var san = SanParser.ExtractSan(cert);
+
+        Assert.Equal("user@example.com", san);
+    }
+
+    [Fact]
+    public void ExtractSan_WithDnsSan_ReturnsDns()
+    {
+        using var cert = CreateCertWithDns("myapp.example.com");
+
+        var san = SanParser.ExtractSan(cert);
+
+        Assert.Equal("myapp.example.com", san);
+    }
+
+    [Fact]
+    public void ExtractSan_WithNoSanExtension_ReturnsNull()
+    {
+        using var cert = CreateCertWithoutSan();
+
+        var san = SanParser.ExtractSan(cert);
+
+        Assert.Null(san);
+    }
+
+    [Fact]
+    public void ExtractSan_WithEmailAndUri_PrefersEmail()
+    {
+        using var cert = CreateCertWithEmailAndUri("user@example.com", "https://example.com");
+
+        var san = SanParser.ExtractSan(cert);
+
+        Assert.Equal("user@example.com", san);
+    }
+
+    [Fact]
+    public void ExtractSan_WithUriAndDns_PrefersUri()
+    {
+        using var cert = CreateCertWithUriAndDns("https://example.com/path", "example.com");
+
+        var san = SanParser.ExtractSan(cert);
+
+        Assert.Equal("https://example.com/path", san);
+    }
+
+    [Fact]
+    public void ExtractSan_WithGitHubActionsUri_ReturnsFullWorkflowUri()
+    {
+        var workflowUri = "https://github.com/microsoft/playwright-cli/.github/workflows/publish.yml@refs/tags/v0.1.1";
+        using var cert = CreateCertWithUri(workflowUri);
+
+        var san = SanParser.ExtractSan(cert);
+
+        Assert.Equal(workflowUri, san);
+    }
+
+    [Fact]
+    public void ExtractSan_WithMalformedRawData_Throws()
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var req = new CertificateRequest("CN=Test", key, HashAlgorithmName.SHA256);
+        req.CertificateExtensions.Add(
+            new X509Extension(new Oid("2.5.29.17"), [0xFF, 0xFE, 0xFD], false));
+        using var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddHours(1));
+
+        Assert.ThrowsAny<AsnContentException>(() => SanParser.ExtractSan(cert));
+    }
+
+    [Fact]
+    public void ExtractSan_WithTruncatedData_Throws()
+    {
+        // A SEQUENCE tag (0x30) with length 10 but only 2 bytes of content
+        byte[] truncated = [0x30, 0x0A, 0x86, 0x04];
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var req = new CertificateRequest("CN=Test", key, HashAlgorithmName.SHA256);
+        req.CertificateExtensions.Add(new X509Extension(new Oid("2.5.29.17"), truncated, false));
+        using var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddHours(1));
+
+        Assert.ThrowsAny<AsnContentException>(() => SanParser.ExtractSan(cert));
+    }
+
+    [Fact]
+    public void ExtractSan_WithEmptySequence_ReturnsNull()
+    {
+        // Valid DER: SEQUENCE with zero content
+        byte[] emptySeq = [0x30, 0x00];
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var req = new CertificateRequest("CN=Test", key, HashAlgorithmName.SHA256);
+        req.CertificateExtensions.Add(new X509Extension(new Oid("2.5.29.17"), emptySeq, false));
+        using var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddHours(1));
+
+        var san = SanParser.ExtractSan(cert);
+
+        Assert.Null(san);
+    }
+
+    [Fact]
+    public void ExtractSan_WithOnlyIpAddress_ReturnsNull()
+    {
+        // SAN with only an iPAddress [7] entry — not a type we extract
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var req = new CertificateRequest("CN=Test", key, HashAlgorithmName.SHA256);
+        var sanBuilder = new SubjectAlternativeNameBuilder();
+        sanBuilder.AddIpAddress(System.Net.IPAddress.Parse("192.168.1.1"));
+        req.CertificateExtensions.Add(sanBuilder.Build());
+        using var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddHours(1));
+
+        var san = SanParser.ExtractSan(cert);
+
+        Assert.Null(san);
+    }
+
+    [Fact]
+    public void ExtractSan_WithMultipleUris_ReturnsFirst()
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var req = new CertificateRequest("CN=Test", key, HashAlgorithmName.SHA256);
+        var sanBuilder = new SubjectAlternativeNameBuilder();
+        sanBuilder.AddUri(new Uri("https://first.example.com/path"));
+        sanBuilder.AddUri(new Uri("https://second.example.com/path"));
+        req.CertificateExtensions.Add(sanBuilder.Build());
+        using var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddHours(1));
+
+        var san = SanParser.ExtractSan(cert);
+
+        Assert.Equal("https://first.example.com/path", san);
+    }
+
+    private static X509Certificate2 CreateCertWithUri(string uri)
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var req = new CertificateRequest("CN=Test", key, HashAlgorithmName.SHA256);
+        var sanBuilder = new SubjectAlternativeNameBuilder();
+        sanBuilder.AddUri(new Uri(uri));
+        req.CertificateExtensions.Add(sanBuilder.Build());
+        return req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddHours(1));
+    }
+
+    private static X509Certificate2 CreateCertWithEmail(string email)
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var req = new CertificateRequest("CN=Test", key, HashAlgorithmName.SHA256);
+        var sanBuilder = new SubjectAlternativeNameBuilder();
+        sanBuilder.AddEmailAddress(email);
+        req.CertificateExtensions.Add(sanBuilder.Build());
+        return req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddHours(1));
+    }
+
+    private static X509Certificate2 CreateCertWithDns(string dns)
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var req = new CertificateRequest("CN=Test", key, HashAlgorithmName.SHA256);
+        var sanBuilder = new SubjectAlternativeNameBuilder();
+        sanBuilder.AddDnsName(dns);
+        req.CertificateExtensions.Add(sanBuilder.Build());
+        return req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddHours(1));
+    }
+
+    private static X509Certificate2 CreateCertWithoutSan()
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var req = new CertificateRequest("CN=Test", key, HashAlgorithmName.SHA256);
+        return req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddHours(1));
+    }
+
+    private static X509Certificate2 CreateCertWithEmailAndUri(string email, string uri)
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var req = new CertificateRequest("CN=Test", key, HashAlgorithmName.SHA256);
+        var sanBuilder = new SubjectAlternativeNameBuilder();
+        sanBuilder.AddEmailAddress(email);
+        sanBuilder.AddUri(new Uri(uri));
+        req.CertificateExtensions.Add(sanBuilder.Build());
+        return req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddHours(1));
+    }
+
+    private static X509Certificate2 CreateCertWithUriAndDns(string uri, string dns)
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var req = new CertificateRequest("CN=Test", key, HashAlgorithmName.SHA256);
+        var sanBuilder = new SubjectAlternativeNameBuilder();
+        sanBuilder.AddUri(new Uri(uri));
+        sanBuilder.AddDnsName(dns);
+        req.CertificateExtensions.Add(sanBuilder.Build());
+        return req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddHours(1));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #14 — `ExtractSan()` fails on Windows and macOS because `X509Extension.Format(false)` returns `URL=` instead of `URI:`.

## Changes

- **New `SanParser.cs`** — parses SAN from raw ASN.1 bytes using `AsnReader`, completely platform-independent
- **Deduplicated** SAN extraction (was copy-pasted in `SigstoreVerifier` and `DefaultSigningCertificateValidator`)
- **CI**: added `windows-latest` to test matrix
- **12 unit tests** covering happy paths, priority ordering, malformed input, empty sequences, unsupported tags, and multiple entries

## Why ASN.1 parsing instead of string fix?

`Format()` is [documented as platform-dependent](https://github.com/dotnet/core/issues/2243) — it delegates to OS crypto libraries:
- Linux/OpenSSL: `URI:https://...`
- Windows/CryptoAPI: `URL=https://...`
- macOS/Apple Security: `URL=https://...`

Adding a `URL` check would be fragile. The ASN.1 approach reads the RFC 5280 structure directly and is already an established pattern in this codebase (`TimestampParser`, `SctVerifier`).

.NET 10 does not have `EnumerateUris()` on `X509SubjectAlternativeNameExtension`, so ASN.1 parsing is the only platform-independent option for URI SANs.