### PR TITLE
ci: add weekly conformance-drift workflow

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -70,109 +70,16 @@ jobs:
           name: test-results-${{ matrix.os }}
           path: ./TestResults/
 
-  conformance-production:
-    runs-on: ubuntu-latest
+  conformance:
     if: ${{ !(inputs.skip_conformance || false) }}
-    timeout-minutes: 30
+    uses: ./.github/workflows/conformance.yml
     permissions:
       contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 10.x
-
-      - name: Publish conformance CLI (native AOT)
-        run: dotnet publish src/Sigstore.Conformance/Sigstore.Conformance.csproj -c Release -r linux-x64
-
-      - name: Create entrypoint wrapper
-        run: |
-          cat > sigstore-conformance-client <<'EOF'
-          #!/bin/bash
-          "$GITHUB_WORKSPACE/src/Sigstore.Conformance/bin/Release/net10.0/linux-x64/publish/Sigstore.Conformance" "$@"
-          EOF
-          chmod +x sigstore-conformance-client
-
-      - name: Run conformance tests (production)
-        uses: sigstore/sigstore-conformance@9611941d54398f2e3f6383b6f744442a56d2fb2a # v0.0.26
-        with:
-          entrypoint: ${{ github.workspace }}/sigstore-conformance-client
-          environment: production
-
-  conformance-staging:
-    runs-on: ubuntu-latest
-    if: ${{ !(inputs.skip_conformance || false) }}
-    timeout-minutes: 30
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 10.x
-
-      - name: Publish conformance CLI (native AOT)
-        run: dotnet publish src/Sigstore.Conformance/Sigstore.Conformance.csproj -c Release -r linux-x64
-
-      - name: Create entrypoint wrapper
-        run: |
-          cat > sigstore-conformance-client <<'EOF'
-          #!/bin/bash
-          "$GITHUB_WORKSPACE/src/Sigstore.Conformance/bin/Release/net10.0/linux-x64/publish/Sigstore.Conformance" "$@"
-          EOF
-          chmod +x sigstore-conformance-client
-
-      - name: Run conformance tests (staging)
-        uses: sigstore/sigstore-conformance@9611941d54398f2e3f6383b6f744442a56d2fb2a # v0.0.26
-        with:
-          entrypoint: ${{ github.workspace }}/sigstore-conformance-client
-          environment: staging
-
-  tuf-conformance:
-    runs-on: ubuntu-latest
-    if: ${{ !(inputs.skip_conformance || false) }}
-    timeout-minutes: 10
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 10.x
-
-      - name: Publish TUF conformance CLI (native AOT)
-        run: dotnet publish src/Tuf.Conformance/Tuf.Conformance.csproj -c Release -r linux-x64
-
-      - name: Create entrypoint wrapper
-        run: |
-          cat > tuf-conformance-client <<'EOF'
-          #!/bin/bash
-          "$GITHUB_WORKSPACE/src/Tuf.Conformance/bin/Release/net10.0/linux-x64/publish/Tuf.Conformance" "$@"
-          EOF
-          chmod +x tuf-conformance-client
-          cp src/Tuf.Conformance/Tuf.Conformance.xfails tuf-conformance-client.xfails
-
-      - name: Run TUF conformance tests
-        uses: theupdateframework/tuf-conformance@500c525c9ce287a472fd334fe8d885cace667d32 # v2.4.0
-        with:
-          entrypoint: ${{ github.workspace }}/tuf-conformance-client
 
   build:
     runs-on: ubuntu-latest
-    needs: [test, conformance-production, conformance-staging, tuf-conformance]
-    if: ${{ !cancelled() && needs.test.result == 'success' && (inputs.skip_conformance || (needs.conformance-production.result == 'success' && needs.conformance-staging.result == 'success' && needs.tuf-conformance.result == 'success')) }}
+    needs: [test, conformance]
+    if: ${{ !cancelled() && needs.test.result == 'success' && (inputs.skip_conformance || needs.conformance.result == 'success') }}
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/conformance-drift.yml
+++ b/.github/workflows/conformance-drift.yml
@@ -1,0 +1,52 @@
+name: Conformance Drift
+
+on:
+  schedule:
+    - cron: '30 9 * * 1' # Every Monday at 9:30 UTC
+  workflow_dispatch:
+
+jobs:
+  conformance:
+    uses: ./.github/workflows/conformance.yml
+    permissions:
+      contents: read
+
+  file-issue:
+    runs-on: ubuntu-latest
+    needs: [conformance]
+    if: ${{ failure() }}
+    permissions:
+      issues: write
+
+    steps:
+      - name: File issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          existing=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "conformance-drift" \
+            --state open \
+            --limit 1 \
+            --json number \
+            --jq '.[0].number // empty')
+
+          body=$(cat <<EOF
+          The weekly conformance-drift workflow detected failures.
+
+          **Workflow run:** ${RUN_URL}
+          EOF
+          )
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" \
+              --repo "${{ github.repository }}" \
+              --body "$body"
+          else
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "Conformance drift detected" \
+              --label "conformance-drift" \
+              --body "$body"
+          fi

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,101 @@
+name: Conformance Tests
+
+on:
+  workflow_call:
+
+jobs:
+  conformance-production:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.x
+
+      - name: Publish conformance CLI (native AOT)
+        run: dotnet publish src/Sigstore.Conformance/Sigstore.Conformance.csproj -c Release -r linux-x64
+
+      - name: Create entrypoint wrapper
+        run: |
+          cat > sigstore-conformance-client <<'EOF'
+          #!/bin/bash
+          "$GITHUB_WORKSPACE/src/Sigstore.Conformance/bin/Release/net10.0/linux-x64/publish/Sigstore.Conformance" "$@"
+          EOF
+          chmod +x sigstore-conformance-client
+
+      - name: Run conformance tests (production)
+        uses: sigstore/sigstore-conformance@9611941d54398f2e3f6383b6f744442a56d2fb2a # v0.0.26
+        with:
+          entrypoint: ${{ github.workspace }}/sigstore-conformance-client
+          environment: production
+
+  conformance-staging:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.x
+
+      - name: Publish conformance CLI (native AOT)
+        run: dotnet publish src/Sigstore.Conformance/Sigstore.Conformance.csproj -c Release -r linux-x64
+
+      - name: Create entrypoint wrapper
+        run: |
+          cat > sigstore-conformance-client <<'EOF'
+          #!/bin/bash
+          "$GITHUB_WORKSPACE/src/Sigstore.Conformance/bin/Release/net10.0/linux-x64/publish/Sigstore.Conformance" "$@"
+          EOF
+          chmod +x sigstore-conformance-client
+
+      - name: Run conformance tests (staging)
+        uses: sigstore/sigstore-conformance@9611941d54398f2e3f6383b6f744442a56d2fb2a # v0.0.26
+        with:
+          entrypoint: ${{ github.workspace }}/sigstore-conformance-client
+          environment: staging
+
+  tuf-conformance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.x
+
+      - name: Publish TUF conformance CLI (native AOT)
+        run: dotnet publish src/Tuf.Conformance/Tuf.Conformance.csproj -c Release -r linux-x64
+
+      - name: Create entrypoint wrapper
+        run: |
+          cat > tuf-conformance-client <<'EOF'
+          #!/bin/bash
+          "$GITHUB_WORKSPACE/src/Tuf.Conformance/bin/Release/net10.0/linux-x64/publish/Tuf.Conformance" "$@"
+          EOF
+          chmod +x tuf-conformance-client
+          cp src/Tuf.Conformance/Tuf.Conformance.xfails tuf-conformance-client.xfails
+
+      - name: Run TUF conformance tests
+        uses: theupdateframework/tuf-conformance@500c525c9ce287a472fd334fe8d885cace667d32 # v2.4.0
+        with:
+          entrypoint: ${{ github.workspace }}/tuf-conformance-client


### PR DESCRIPTION
Extract the three conformance jobs (production, staging, TUF) into a reusable \conformance.yml\ workflow called by both \uild-deploy.yml\ and a new \conformance-drift.yml\.

### What's new

- **\.github/workflows/conformance.yml\** — reusable workflow (\workflow_call\) with all three conformance jobs.
- **\.github/workflows/conformance-drift.yml\** — weekly schedule (Monday 9:30 UTC) + \workflow_dispatch\. On failure it files (or comments on) a GitHub issue labelled \conformance-drift\ with a link to the failed run.
- **\.github/workflows/build-deploy.yml\** — conformance jobs replaced with a single caller into the shared workflow.