### PR TITLE
Replace NSec with BouncyCastle, harden verification, and modernize releases

### DIFF
--- a/.github/actions/baseline-bump/bump.sh
+++ b/.github/actions/baseline-bump/bump.sh
@@ -1,0 +1,95 @@
+set -euo pipefail
+
+# Opens (or updates) a pull request that bumps the package validation baseline on BRANCH to
+# VERSION. Idempotent: if the projects on BRANCH already pin VERSION the script exits without
+# touching git or the pull request.
+#
+# Inputs:
+#   $1 BRANCH  - the base branch to target (e.g. main, release/0.5)
+#   $2 VERSION - the stable X.Y.Z to pin as the baseline
+#
+# Requires the gh CLI authenticated with pull-request write access.
+
+BRANCH="${1:?branch required}"
+VERSION="${2:?version required}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECTS=(src/Sigstore/Sigstore.csproj src/Tuf/Tuf.csproj)
+
+if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+  echo "::notice::Branch '$BRANCH' does not exist on origin; skipping."
+  exit 0
+fi
+
+WORKTREE="$(mktemp -d)"
+cleanup() {
+  git worktree remove --force "$WORKTREE" >/dev/null 2>&1 || true
+  rm -rf "$WORKTREE"
+}
+trap cleanup EXIT
+
+git fetch origin "$BRANCH" --quiet
+git worktree add --detach "$WORKTREE" "origin/$BRANCH" >/dev/null
+
+pushd "$WORKTREE" >/dev/null
+
+for project in "${PROJECTS[@]}"; do
+  if [[ ! -f "$project" ]]; then
+    echo "::notice::$project is not present on $BRANCH; skipping."
+    popd >/dev/null
+    exit 0
+  fi
+done
+
+PREVIOUS="$(VERSION="$VERSION" bash "$SCRIPT_DIR/rewrite.sh" "${PROJECTS[@]}")"
+
+if git diff --quiet -- "${PROJECTS[@]}"; then
+  echo "Baseline on $BRANCH is already $VERSION; nothing to do."
+  popd >/dev/null
+  exit 0
+fi
+
+# Reuse the head branch of an open bump pull request so it is updated in place, otherwise
+# mint a version-suffixed head branch so a previously merged or closed bump is not disturbed.
+BRANCH_SLUG="${BRANCH//\//-}"
+
+EXISTING_HEAD="$(gh pr list \
+  --base "$BRANCH" \
+  --state open \
+  --json headRefName \
+  --jq "[.[] | select(.headRefName | startswith(\"bot/baseline-bump/${BRANCH_SLUG}\"))][0].headRefName // empty" \
+  2>/dev/null || true)"
+
+if [[ -n "$EXISTING_HEAD" ]]; then
+  HEAD_BRANCH="$EXISTING_HEAD"
+  echo "Reusing open bump pull request head '$HEAD_BRANCH'."
+else
+  HEAD_BRANCH="bot/baseline-bump/${BRANCH_SLUG}-to-${VERSION}"
+fi
+
+git checkout -B "$HEAD_BRANCH" --quiet
+git add "${PROJECTS[@]}"
+git commit --quiet -m "ci: pin package validation baseline to $VERSION on $BRANCH"
+git push --force-with-lease --quiet origin "$HEAD_BRANCH"
+
+TITLE="Pin package validation baseline to $VERSION on $BRANCH"
+BODY="$(cat <<EOF
+Pins \`<PackageValidationBaselineVersion>\` in \`src/Sigstore/Sigstore.csproj\` and
+\`src/Tuf/Tuf.csproj\` to **$VERSION**, following the stable release on \`$BRANCH\`.
+
+- Previous baseline: \`${PREVIOUS:-none}\`
+- New baseline: \`$VERSION\`
+
+Once merged, every build on \`$BRANCH\` compares the public API against the $VERSION packages
+on NuGet.org and fails on an undeclared breaking change. See
+\`.github/workflows/baseline-bump.yml\` for when this pull request is raised.
+EOF
+)"
+
+if [[ -n "$EXISTING_HEAD" ]]; then
+  gh pr edit "$HEAD_BRANCH" --title "$TITLE" --body "$BODY"
+else
+  gh pr create --base "$BRANCH" --head "$HEAD_BRANCH" --title "$TITLE" --body "$BODY"
+fi
+
+popd >/dev/null

--- a/.github/actions/baseline-bump/resolve.sh
+++ b/.github/actions/baseline-bump/resolve.sh
@@ -1,0 +1,73 @@
+set -euo pipefail
+
+# Resolves the stable release whose API becomes the new package validation baseline, and
+# decides which branches should be offered a bump.
+#
+# A bump always targets release/X.Y so the next patch on that servicing line validates
+# against the release that just shipped. It targets main only when X.Y is the highest minor
+# of the highest released major, because main must not be pulled backwards to an older
+# servicing line. When a release branch is later cut from main it inherits main's baseline,
+# so no extra handling is needed here.
+
+: "${EVENT_NAME:?EVENT_NAME is required}"
+: "${RELEASE_TAG:=}"
+: "${INPUT_VERSION:=}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+git fetch origin --tags --force --quiet
+
+stable_tags() {
+  git tag -l 'v*.*.*' \
+    | sed -E 's@^v@@' \
+    | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true
+}
+
+skip() {
+  echo "::notice::$1"
+  echo "skip=true" >> "$GITHUB_OUTPUT"
+  exit 0
+}
+
+if [[ "$EVENT_NAME" == "release" ]]; then
+  RAW="$RELEASE_TAG"
+elif [[ -n "$INPUT_VERSION" ]]; then
+  RAW="$INPUT_VERSION"
+else
+  RAW="$(stable_tags | sort -t. -k1,1n -k2,2n -k3,3n | tail -n1)"
+  [[ -n "$RAW" ]] || skip "No stable tags exist; nothing to bump."
+fi
+
+VERSION="${RAW#v}"
+
+if [[ ! "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  skip "'$RAW' is not a stable vX.Y.Z; skipping."
+fi
+
+MAJOR="${BASH_REMATCH[1]}"
+MINOR="${BASH_REMATCH[2]}"
+
+# The released version is folded into the comparison so a line released right now still
+# counts as the latest even if its tag is not visible locally.
+HIGHEST_MAJOR="$( { stable_tags; echo "$VERSION"; } | awk -F. '{print $1}' | sort -n | tail -n1)"
+
+HIGHEST_MINOR="$( {
+  stable_tags | awk -F. -v major="$HIGHEST_MAJOR" '$1 == major {print $2}'
+  if [[ "$MAJOR" == "$HIGHEST_MAJOR" ]]; then echo "$MINOR"; fi
+} | sort -n | tail -n1)"
+
+BUMP_MAIN=false
+if [[ "$MAJOR" == "$HIGHEST_MAJOR" && "$MINOR" == "$HIGHEST_MINOR" ]]; then
+  BUMP_MAIN=true
+fi
+
+{
+  echo "skip=false"
+  echo "version=$VERSION"
+  echo "major=$MAJOR"
+  echo "minor=$MINOR"
+  echo "bump_main=$BUMP_MAIN"
+} >> "$GITHUB_OUTPUT"
+
+echo "Baseline version : $VERSION"
+echo "Release branch   : release/${MAJOR}.${MINOR}"
+echo "Bump main?       : $BUMP_MAIN"

--- a/.github/actions/baseline-bump/rewrite.sh
+++ b/.github/actions/baseline-bump/rewrite.sh
@@ -1,0 +1,69 @@
+set -euo pipefail
+
+# Rewrites the bot-managed <PackageValidationBaselineVersion> block in each project file
+# passed as an argument, and prints the previous baseline of the first file that had one.
+#
+# Only the lines between the markers are touched, so hand-written package metadata around
+# the block is preserved. Rewriting is idempotent: running it twice with the same version
+# leaves the file byte-identical.
+
+: "${VERSION:?VERSION is required}"
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "::error::VERSION '$VERSION' is not a stable X.Y.Z." >&2
+  exit 1
+fi
+
+if [[ $# -eq 0 ]]; then
+  echo "::error::At least one project file is required." >&2
+  exit 1
+fi
+
+BEGIN_MARKER="<!-- BEGIN: bot-managed baseline -->"
+END_MARKER="<!-- END: bot-managed baseline -->"
+
+PREVIOUS=""
+
+for project in "$@"; do
+  if [[ ! -f "$project" ]]; then
+    echo "::error::$project does not exist." >&2
+    exit 1
+  fi
+
+  if ! grep -qF "$BEGIN_MARKER" "$project" || ! grep -qF "$END_MARKER" "$project"; then
+    echo "::error::bot-managed baseline block not found in $project." >&2
+    exit 1
+  fi
+
+  current="$(sed -n "/$(printf '%s' "$BEGIN_MARKER" | sed 's@[]\/$*.^[]@\\&@g')/,/$(printf '%s' "$END_MARKER" | sed 's@[]\/$*.^[]@\\&@g')/p" "$project" \
+    | grep -oE '<PackageValidationBaselineVersion>[^<]+</PackageValidationBaselineVersion>' \
+    | head -n1 \
+    | sed -E 's@</?PackageValidationBaselineVersion>@@g' || true)"
+
+  if [[ -z "$PREVIOUS" && -n "$current" ]]; then
+    PREVIOUS="$current"
+  fi
+
+  rewritten="$(mktemp)"
+  awk -v version="$VERSION" -v begin_marker="$BEGIN_MARKER" -v end_marker="$END_MARKER" '
+    index($0, begin_marker) {
+      match($0, /^[ \t]*/)
+      indent = substr($0, 1, RLENGTH)
+      print
+      inside = 1
+      next
+    }
+    inside && index($0, end_marker) {
+      print indent "<PackageValidationBaselineVersion>" version "</PackageValidationBaselineVersion>"
+      print
+      inside = 0
+      next
+    }
+    inside { next }
+    { print }
+  ' "$project" > "$rewritten"
+
+  mv "$rewritten" "$project"
+done
+
+echo "$PREVIOUS"

--- a/.github/actions/baseline-bump/test.sh
+++ b/.github/actions/baseline-bump/test.sh
@@ -1,0 +1,192 @@
+set -euo pipefail
+
+# Exercises resolve.sh against synthetic tag histories and rewrite.sh against synthetic
+# project files. bump.sh is not covered here because it talks to GitHub.
+
+ACTION_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+FAILURES=0
+
+fail() {
+  echo "FAIL: $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+# ---------------------------------------------------------------------------
+# resolve.sh
+# ---------------------------------------------------------------------------
+
+git init --bare --quiet "$TEST_ROOT/origin.git"
+git init --quiet --initial-branch=main "$TEST_ROOT/work"
+cd "$TEST_ROOT/work"
+git config user.email "baseline-tests@example.invalid"
+git config user.name "Baseline Tests"
+echo "baseline tests" > README.md
+git add README.md
+git commit --quiet -m "Initial commit"
+git remote add origin "$TEST_ROOT/origin.git"
+git push --quiet --set-upstream origin main
+
+tag() {
+  git tag "$1"
+  git push --quiet origin "$1"
+}
+
+resolve_case() {
+  local description="$1" event_name="$2" release_tag="$3" input_version="$4"
+  shift 4
+  local output
+  output="$(mktemp "$TEST_ROOT/output.XXXXXX")"
+
+  EVENT_NAME="$event_name" \
+  RELEASE_TAG="$release_tag" \
+  INPUT_VERSION="$input_version" \
+  GITHUB_OUTPUT="$output" \
+    bash "$ACTION_PATH/resolve.sh" >/dev/null
+
+  local expectation
+  for expectation in "$@"; do
+    grep -Fxq "$expectation" "$output" || fail "$description: expected '$expectation' in $(tr '\n' ' ' < "$output")"
+  done
+}
+
+resolve_case "no tags at all" workflow_dispatch "" "" "skip=true"
+
+tag v0.5.0
+
+resolve_case "release event on the only line" release v0.5.0 "" \
+  "skip=false" "version=0.5.0" "major=0" "minor=5" "bump_main=true"
+
+resolve_case "dispatch falls back to the highest tag" workflow_dispatch "" "" \
+  "skip=false" "version=0.5.0" "bump_main=true"
+
+resolve_case "dispatch honours an explicit version" workflow_dispatch "" 0.5.0 \
+  "skip=false" "version=0.5.0"
+
+resolve_case "prerelease tags are ignored" release v0.6.0-dev "" "skip=true"
+resolve_case "non-version tags are ignored" release nightly "" "skip=true"
+
+tag v0.6.0
+
+resolve_case "servicing an older minor leaves main alone" release v0.5.0 "" \
+  "skip=false" "version=0.5.0" "minor=5" "bump_main=false"
+
+resolve_case "the newest minor also bumps main" release v0.6.0 "" \
+  "skip=false" "version=0.6.0" "minor=6" "bump_main=true"
+
+tag v0.10.0
+
+resolve_case "minors are compared numerically" release v0.10.0 "" \
+  "skip=false" "version=0.10.0" "minor=10" "bump_main=true"
+
+resolve_case "0.6.0 is not the newest once 0.10.0 exists" release v0.6.0 "" \
+  "skip=false" "bump_main=false"
+
+tag v1.0.0
+
+resolve_case "a new major takes over main" release v1.0.0 "" \
+  "skip=false" "version=1.0.0" "major=1" "minor=0" "bump_main=true"
+
+resolve_case "the previous major no longer bumps main" release v0.10.0 "" \
+  "skip=false" "bump_main=false"
+
+resolve_case "a patch on the newest line bumps main" release v1.0.1 "" \
+  "skip=false" "version=1.0.1" "bump_main=true"
+
+# ---------------------------------------------------------------------------
+# rewrite.sh
+# ---------------------------------------------------------------------------
+
+make_project() {
+  cat > "$1" <<'EOF'
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Example</PackageId>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <!-- BEGIN: bot-managed baseline -->
+    <PackageValidationBaselineVersion>0.4.0</PackageValidationBaselineVersion>
+    <!-- END: bot-managed baseline -->
+    <Description>Example</Description>
+  </PropertyGroup>
+
+</Project>
+EOF
+}
+
+PROJECT_A="$TEST_ROOT/A.csproj"
+PROJECT_B="$TEST_ROOT/B.csproj"
+make_project "$PROJECT_A"
+make_project "$PROJECT_B"
+
+PREVIOUS="$(VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh" "$PROJECT_A" "$PROJECT_B")"
+[[ "$PREVIOUS" == "0.4.0" ]] || fail "rewrite reports the previous baseline (got '$PREVIOUS')"
+
+grep -q '<PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>' "$PROJECT_A" \
+  || fail "rewrite pins the new version"
+grep -q '<PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>' "$PROJECT_B" \
+  || fail "rewrite pins every project passed to it"
+grep -q '<Description>Example</Description>' "$PROJECT_A" \
+  || fail "rewrite preserves content after the block"
+grep -q '<EnablePackageValidation>true</EnablePackageValidation>' "$PROJECT_A" \
+  || fail "rewrite preserves content before the block"
+grep -q '^    <PackageValidationBaselineVersion>' "$PROJECT_A" \
+  || fail "rewrite preserves the indentation of the block"
+[[ "$(grep -c '<PackageValidationBaselineVersion>' "$PROJECT_A")" == "1" ]] \
+  || fail "rewrite leaves exactly one baseline element"
+
+cp "$PROJECT_A" "$TEST_ROOT/A.before"
+VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh" "$PROJECT_A" >/dev/null
+cmp -s "$PROJECT_A" "$TEST_ROOT/A.before" || fail "rewrite is idempotent"
+
+# A block that lost its element still gets one back, so a hand-edited project recovers.
+cat > "$TEST_ROOT/empty.csproj" <<'EOF'
+<Project>
+  <PropertyGroup>
+    <!-- BEGIN: bot-managed baseline -->
+    <!-- END: bot-managed baseline -->
+  </PropertyGroup>
+</Project>
+EOF
+PREVIOUS="$(VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh" "$TEST_ROOT/empty.csproj")"
+[[ -z "$PREVIOUS" ]] || fail "rewrite reports no previous baseline for an empty block (got '$PREVIOUS')"
+grep -q '<PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>' "$TEST_ROOT/empty.csproj" \
+  || fail "rewrite repopulates an empty block"
+
+expect_failure() {
+  local description="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    fail "$description"
+  fi
+}
+
+cat > "$TEST_ROOT/nomarkers.csproj" <<'EOF'
+<Project>
+  <PropertyGroup />
+</Project>
+EOF
+expect_failure "rewrite rejects a project without markers" \
+  env VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh" "$TEST_ROOT/nomarkers.csproj"
+
+expect_failure "rewrite rejects a missing project" \
+  env VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh" "$TEST_ROOT/absent.csproj"
+
+expect_failure "rewrite rejects a prerelease version" \
+  env VERSION=0.5.0-beta.1 bash "$ACTION_PATH/rewrite.sh" "$PROJECT_A"
+
+expect_failure "rewrite requires at least one project" \
+  env VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh"
+
+# A project that fails validation must be left untouched.
+grep -q '<PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>' "$PROJECT_A" \
+  || fail "a rejected run leaves the project untouched"
+
+if [[ "$FAILURES" -gt 0 ]]; then
+  echo "$FAILURES baseline bump test(s) failed."
+  exit 1
+fi
+
+echo "All baseline bump tests passed."

--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -1,102 +1,36 @@
-name: 'Generate Version'
-description: 'Generates version strings for NuGet packages based on git tags and branch context'
+name: Generate Sigstore version
+description: Compute the package version from the target branch and build context.
 
 inputs:
-  release:
-    description: 'Whether this is a GA release build (no prerelease suffix)'
+  release-flag:
+    description: Publish a final release from a release/X.Y branch.
     required: false
-    default: 'false'
+    default: "false"
 
 outputs:
   version:
-    description: 'The computed package version for this build'
-    value: ${{ steps.version.outputs.version }}
-  base_version:
-    description: 'The base X.Y.Z version (no suffix)'
-    value: ${{ steps.version.outputs.base_version }}
-  is_release:
-    description: 'Whether this is a GA release'
-    value: ${{ steps.version.outputs.is_release }}
+    description: Full NuGet package version.
+    value: ${{ steps.compute.outputs.version }}
+  kind:
+    description: alpha, beta, release, or pr.
+    value: ${{ steps.compute.outputs.kind }}
+  base:
+    description: Stable X.Y.Z version without a prerelease suffix.
+    value: ${{ steps.compute.outputs.base }}
 
 runs:
-  using: 'composite'
+  using: composite
   steps:
     - name: Compute version
-      id: version
+      id: compute
       shell: bash
-      run: |
-        set -e
-        git fetch --tags --quiet 2>/dev/null || true
-
-        BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-        EVENT="${GITHUB_EVENT_NAME}"
-        IS_RELEASE="${{ inputs.release }}"
-        SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
-        RUN_ID="${GITHUB_RUN_ID}"
-        ATTEMPT="${GITHUB_RUN_ATTEMPT}"
-        PR_NUMBER="${{ github.event.pull_request.number }}"
-
-        echo "Branch: $BRANCH | Event: $EVENT | Release: $IS_RELEASE"
-
-        # Determine if we're on a release branch
-        if [[ "$BRANCH" == release/* ]]; then
-          # Extract X.Y from release/X.Y
-          RELEASE_XY="${BRANCH#release/}"
-          MAJOR=$(echo "$RELEASE_XY" | cut -d'.' -f1)
-          MINOR=$(echo "$RELEASE_XY" | cut -d'.' -f2)
-
-          # Find latest vX.Y.* release tag to determine patch
-          LATEST_PATCH_TAG=$(git tag -l "v${MAJOR}.${MINOR}.*" | { grep -v '-' || true; } | sort -V | tail -n1)
-          if [ -n "$LATEST_PATCH_TAG" ]; then
-            LATEST_PATCH=$(echo "${LATEST_PATCH_TAG#v}" | cut -d'.' -f3)
-            PATCH=$((LATEST_PATCH + 1))
-          else
-            PATCH=0
-          fi
-
-          BASE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-
-          if [ "$IS_RELEASE" = "true" ]; then
-            VERSION="${BASE_VERSION}"
-            echo "is_release=true" >> $GITHUB_OUTPUT
-          elif [ "$EVENT" = "pull_request" ]; then
-            VERSION="${BASE_VERSION}-pr.${PR_NUMBER}.${RUN_ID}.${SHORT_SHA}.${ATTEMPT}"
-            echo "is_release=false" >> $GITHUB_OUTPUT
-          else
-            VERSION="${BASE_VERSION}-rc.${RUN_ID}.${SHORT_SHA}.${ATTEMPT}"
-            echo "is_release=false" >> $GITHUB_OUTPUT
-          fi
-        else
-          # Main branch (or other)
-          # Check for a dev marker tag (vX.Y.0-dev) on main
-          DEV_TAG=$(git tag -l 'v*.*.*-dev' --sort=-v:refname | head -n1)
-          if [ -n "$DEV_TAG" ]; then
-            DEV_VERSION="${DEV_TAG#v}"
-            DEV_VERSION="${DEV_VERSION%-dev}"
-            MAJOR=$(echo "$DEV_VERSION" | cut -d'.' -f1)
-            MINOR=$(echo "$DEV_VERSION" | cut -d'.' -f2)
-            BASE_VERSION="${MAJOR}.${MINOR}.0"
-          else
-            # Fall back to latest release tag and use its major.minor
-            LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | grep -v '-' | sort -V | tail -n1)
-            if [ -n "$LATEST_TAG" ]; then
-              LATEST_VERSION="${LATEST_TAG#v}"
-              MAJOR=$(echo "$LATEST_VERSION" | cut -d'.' -f1)
-              MINOR=$(echo "$LATEST_VERSION" | cut -d'.' -f2)
-              BASE_VERSION="${MAJOR}.${MINOR}.0"
-            else
-              BASE_VERSION="0.1.0"
-            fi
-          fi
-
-          if [ "$EVENT" = "pull_request" ]; then
-            VERSION="${BASE_VERSION}-pr.${PR_NUMBER}.${RUN_ID}.${SHORT_SHA}.${ATTEMPT}"
-          else
-            VERSION="${BASE_VERSION}-dev.${RUN_ID}.${SHORT_SHA}.${ATTEMPT}"
-          fi
-          echo "is_release=false" >> $GITHUB_OUTPUT
-        fi
-
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-        echo "base_version=$BASE_VERSION" >> $GITHUB_OUTPUT
-        echo "Computed version: $VERSION (base: $BASE_VERSION)"
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        REF_NAME: ${{ github.ref_name }}
+        BASE_REF: ${{ github.base_ref }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        RUN_NUMBER: ${{ github.run_number }}
+        RUN_ATTEMPT: ${{ github.run_attempt }}
+        GIT_SHA: ${{ github.sha }}
+        RELEASE_FLAG: ${{ inputs.release-flag }}
+      run: bash "$GITHUB_ACTION_PATH/version.sh"

--- a/.github/actions/version/test.sh
+++ b/.github/actions/version/test.sh
@@ -44,14 +44,15 @@ run_case() {
   grep -Fxq "version=$expected_version" "$output"
 }
 
-run_case alpha 0.1.0 "0.1.0-alpha.12.3.${SHORT_SHA}" push main
+run_case alpha 1.0.0 "1.0.0-alpha.12.3.${SHORT_SHA}" push main
 
 git tag v0.3.2
 git tag v9.9.9-beta.1
 git push --quiet origin --tags
 git push --quiet origin HEAD:refs/heads/release/0.4
 
-run_case alpha 0.5.0 "0.5.0-alpha.12.3.${SHORT_SHA}" push main
+# The 0.x line is closed, so main opens at 1.0.0 regardless of how far 0.x progressed.
+run_case alpha 1.0.0 "1.0.0-alpha.12.3.${SHORT_SHA}" push main
 run_case pr 0.4.0 "0.4.0-pr.42.12.3.${SHORT_SHA}" pull_request ignored release/0.4
 run_case beta 0.4.0 "0.4.0-beta.12.3.${SHORT_SHA}" push release/0.4
 
@@ -61,6 +62,23 @@ git push --quiet origin --tags
 
 run_case beta 0.4.3 "0.4.3-beta.12.3.${SHORT_SHA}" push release/0.4
 run_case release 0.4.3 0.4.3 workflow_dispatch release/0.4 "" true
+
+# Cutting the first 1.x line: the branch itself opens at 1.0.0 and main advances past it.
+run_case beta 1.0.0 "1.0.0-beta.12.3.${SHORT_SHA}" push release/1.0
+git push --quiet origin HEAD:refs/heads/release/1.0
+run_case alpha 1.1.0 "1.1.0-alpha.12.3.${SHORT_SHA}" push main
+run_case release 1.0.0 1.0.0 workflow_dispatch release/1.0 "" true
+
+# Once 1.0.0 ships, that line services patches while main stays on the next minor.
+git tag v1.0.0
+git push --quiet origin --tags
+run_case beta 1.0.1 "1.0.1-beta.12.3.${SHORT_SHA}" push release/1.0
+run_case alpha 1.1.0 "1.1.0-alpha.12.3.${SHORT_SHA}" push main
+
+# A later minor moves main on without needing a release branch to exist first.
+git tag v1.2.0
+git push --quiet origin --tags
+run_case alpha 1.3.0 "1.3.0-alpha.12.3.${SHORT_SHA}" push main
 
 if EVENT_NAME=push REF_NAME=feature/test BASE_REF="" PR_NUMBER=42 RUN_NUMBER=12 RUN_ATTEMPT=3 \
   GIT_SHA="$(git rev-parse HEAD)" RELEASE_FLAG=false GITHUB_OUTPUT="$TEST_ROOT/unsupported.out" \

--- a/.github/actions/version/test.sh
+++ b/.github/actions/version/test.sh
@@ -1,0 +1,79 @@
+set -euo pipefail
+
+ACTION_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+git init --bare --quiet "$TEST_ROOT/origin.git"
+git init --quiet --initial-branch=main "$TEST_ROOT/work"
+cd "$TEST_ROOT/work"
+git config user.email "version-tests@example.invalid"
+git config user.name "Version Tests"
+echo "version tests" > README.md
+git add README.md
+git commit --quiet -m "Initial commit"
+git remote add origin "$TEST_ROOT/origin.git"
+git push --quiet --set-upstream origin main
+
+SHORT_SHA="$(git rev-parse --short=7 HEAD)"
+
+run_case() {
+  local expected_kind="$1"
+  local expected_base="$2"
+  local expected_version="$3"
+  local event_name="$4"
+  local ref_name="$5"
+  local base_ref="${6:-}"
+  local release_flag="${7:-false}"
+  local output
+  output="$(mktemp "$TEST_ROOT/output.XXXXXX")"
+
+  EVENT_NAME="$event_name" \
+  REF_NAME="$ref_name" \
+  BASE_REF="$base_ref" \
+  PR_NUMBER=42 \
+  RUN_NUMBER=12 \
+  RUN_ATTEMPT=3 \
+  GIT_SHA="$(git rev-parse HEAD)" \
+  RELEASE_FLAG="$release_flag" \
+  GITHUB_OUTPUT="$output" \
+    bash "$ACTION_PATH/version.sh" >/dev/null
+
+  grep -Fxq "kind=$expected_kind" "$output"
+  grep -Fxq "base=$expected_base" "$output"
+  grep -Fxq "version=$expected_version" "$output"
+}
+
+run_case alpha 0.1.0 "0.1.0-alpha.12.3.${SHORT_SHA}" push main
+
+git tag v0.3.2
+git tag v9.9.9-beta.1
+git push --quiet origin --tags
+git push --quiet origin HEAD:refs/heads/release/0.4
+
+run_case alpha 0.5.0 "0.5.0-alpha.12.3.${SHORT_SHA}" push main
+run_case pr 0.4.0 "0.4.0-pr.42.12.3.${SHORT_SHA}" pull_request ignored release/0.4
+run_case beta 0.4.0 "0.4.0-beta.12.3.${SHORT_SHA}" push release/0.4
+
+git tag v0.4.0
+git tag v0.4.2
+git push --quiet origin --tags
+
+run_case beta 0.4.3 "0.4.3-beta.12.3.${SHORT_SHA}" push release/0.4
+run_case release 0.4.3 0.4.3 workflow_dispatch release/0.4 "" true
+
+if EVENT_NAME=push REF_NAME=feature/test BASE_REF="" PR_NUMBER=42 RUN_NUMBER=12 RUN_ATTEMPT=3 \
+  GIT_SHA="$(git rev-parse HEAD)" RELEASE_FLAG=false GITHUB_OUTPUT="$TEST_ROOT/unsupported.out" \
+  bash "$ACTION_PATH/version.sh" >/dev/null 2>&1; then
+  echo "Unsupported branches must fail."
+  exit 1
+fi
+
+if EVENT_NAME=workflow_dispatch REF_NAME=main BASE_REF="" PR_NUMBER=42 RUN_NUMBER=12 RUN_ATTEMPT=3 \
+  GIT_SHA="$(git rev-parse HEAD)" RELEASE_FLAG=true GITHUB_OUTPUT="$TEST_ROOT/main-release.out" \
+  bash "$ACTION_PATH/version.sh" >/dev/null 2>&1; then
+  echo "Stable releases from main must fail."
+  exit 1
+fi
+
+echo "Version calculation tests passed."

--- a/.github/actions/version/version.sh
+++ b/.github/actions/version/version.sh
@@ -15,6 +15,11 @@ git ls-remote origin HEAD >/dev/null
 
 SHORT_SHA="${GIT_SHA:0:7}"
 
+# The 0.x series is closed. Every 0.x package shipped assembly version 1.0.0.0, so a package
+# version below 1.0.0 would derive an assembly version that goes backwards and package
+# validation rejects it (CP0003). New lines off main therefore start at 1.0.
+MINIMUM_MAJOR=1
+
 highest_release_branch_minor() {
   git ls-remote --heads origin 'refs/heads/release/*' \
     | awk '{print $2}' \
@@ -74,16 +79,23 @@ if [[ "$TARGET" == "main" ]]; then
     MAJOR="$BRANCH_MAJOR"
   fi
 
-  HIGHEST_MINOR=0
-  TAG_MINOR="$(highest_tag_minor_for_major "$MAJOR" || true)"
-  if [[ -n "$TAG_MINOR" && "$TAG_MINOR" -gt "$HIGHEST_MINOR" ]]; then
-    HIGHEST_MINOR="$TAG_MINOR"
-  fi
-  if [[ -n "$BRANCH_MINOR" && "$BRANCH_MAJOR" == "$MAJOR" && "$BRANCH_MINOR" -gt "$HIGHEST_MINOR" ]]; then
-    HIGHEST_MINOR="$BRANCH_MINOR"
+  if [[ "$MAJOR" -lt "$MINIMUM_MAJOR" ]]; then
+    # Nothing has been released or branched in the minimum major yet, so it opens at .0.
+    MAJOR="$MINIMUM_MAJOR"
+    BASE="${MAJOR}.0.0"
+  else
+    HIGHEST_MINOR=0
+    TAG_MINOR="$(highest_tag_minor_for_major "$MAJOR" || true)"
+    if [[ -n "$TAG_MINOR" && "$TAG_MINOR" -gt "$HIGHEST_MINOR" ]]; then
+      HIGHEST_MINOR="$TAG_MINOR"
+    fi
+    if [[ -n "$BRANCH_MINOR" && "$BRANCH_MAJOR" == "$MAJOR" && "$BRANCH_MINOR" -gt "$HIGHEST_MINOR" ]]; then
+      HIGHEST_MINOR="$BRANCH_MINOR"
+    fi
+
+    BASE="${MAJOR}.$((HIGHEST_MINOR + 1)).0"
   fi
 
-  BASE="${MAJOR}.$((HIGHEST_MINOR + 1)).0"
   BRANCH_KIND="alpha"
 elif [[ "$TARGET" =~ ^release/([0-9]+)\.([0-9]+)$ ]]; then
   MAJOR="${BASH_REMATCH[1]}"

--- a/.github/actions/version/version.sh
+++ b/.github/actions/version/version.sh
@@ -1,0 +1,141 @@
+set -euo pipefail
+
+: "${EVENT_NAME:?EVENT_NAME is required}"
+: "${REF_NAME:=}"
+: "${BASE_REF:=}"
+: "${PR_NUMBER:=}"
+: "${RUN_NUMBER:?RUN_NUMBER is required}"
+: "${RUN_ATTEMPT:?RUN_ATTEMPT is required}"
+: "${GIT_SHA:?GIT_SHA is required}"
+: "${RELEASE_FLAG:=false}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+git fetch origin --tags --force --quiet
+git ls-remote origin HEAD >/dev/null
+
+SHORT_SHA="${GIT_SHA:0:7}"
+
+highest_release_branch_minor() {
+  git ls-remote --heads origin 'refs/heads/release/*' \
+    | awk '{print $2}' \
+    | sed -E 's@^refs/heads/release/@@' \
+    | grep -E '^[0-9]+\.[0-9]+$' \
+    | sort -t. -k1,1n -k2,2n \
+    | tail -n1 \
+    | awk -F. '{print $1, $2}'
+}
+
+highest_tag_major() {
+  git tag -l 'v*.*.*' \
+    | sed -E 's@^v@@' \
+    | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+    | awk -F. '{print $1}' \
+    | sort -n \
+    | tail -n1
+}
+
+highest_tag_minor_for_major() {
+  local major="$1"
+  git tag -l "v${major}.*.*" \
+    | sed -E "s@^v${major}\\.@@" \
+    | grep -E '^[0-9]+\.[0-9]+$' \
+    | awk -F. '{print $1}' \
+    | sort -n \
+    | tail -n1
+}
+
+highest_tag_patch_for() {
+  local major="$1" minor="$2"
+  git tag -l "v${major}.${minor}.*" \
+    | sed -E "s@^v${major}\\.${minor}\\.@@" \
+    | grep -E '^[0-9]+$' \
+    | sort -n \
+    | tail -n1
+}
+
+if [[ "$EVENT_NAME" == "pull_request" ]]; then
+  TARGET="$BASE_REF"
+else
+  TARGET="$REF_NAME"
+fi
+
+if [[ "$TARGET" == "main" ]]; then
+  MAJOR="$(highest_tag_major || true)"
+  MAJOR="${MAJOR:-0}"
+  BRANCH_INFO="$(highest_release_branch_minor || true)"
+  BRANCH_MAJOR=""
+  BRANCH_MINOR=""
+  if [[ -n "$BRANCH_INFO" ]]; then
+    BRANCH_MAJOR="${BRANCH_INFO%% *}"
+    BRANCH_MINOR="${BRANCH_INFO##* }"
+  fi
+
+  if [[ -n "$BRANCH_MAJOR" && "$BRANCH_MAJOR" -gt "$MAJOR" ]]; then
+    MAJOR="$BRANCH_MAJOR"
+  fi
+
+  HIGHEST_MINOR=0
+  TAG_MINOR="$(highest_tag_minor_for_major "$MAJOR" || true)"
+  if [[ -n "$TAG_MINOR" && "$TAG_MINOR" -gt "$HIGHEST_MINOR" ]]; then
+    HIGHEST_MINOR="$TAG_MINOR"
+  fi
+  if [[ -n "$BRANCH_MINOR" && "$BRANCH_MAJOR" == "$MAJOR" && "$BRANCH_MINOR" -gt "$HIGHEST_MINOR" ]]; then
+    HIGHEST_MINOR="$BRANCH_MINOR"
+  fi
+
+  BASE="${MAJOR}.$((HIGHEST_MINOR + 1)).0"
+  BRANCH_KIND="alpha"
+elif [[ "$TARGET" =~ ^release/([0-9]+)\.([0-9]+)$ ]]; then
+  MAJOR="${BASH_REMATCH[1]}"
+  MINOR="${BASH_REMATCH[2]}"
+  LAST_PATCH="$(highest_tag_patch_for "$MAJOR" "$MINOR" || true)"
+  if [[ -z "$LAST_PATCH" ]]; then
+    PATCH=0
+  else
+    PATCH=$((LAST_PATCH + 1))
+  fi
+  BASE="${MAJOR}.${MINOR}.${PATCH}"
+  BRANCH_KIND="beta"
+else
+  echo "::error::Unsupported branch '$TARGET'. Use main or release/X.Y."
+  exit 1
+fi
+
+case "$EVENT_NAME" in
+  pull_request)
+    KIND="pr"
+    VERSION="${BASE}-pr.${PR_NUMBER}.${RUN_NUMBER}.${RUN_ATTEMPT}.${SHORT_SHA}"
+    ;;
+  push)
+    KIND="$BRANCH_KIND"
+    VERSION="${BASE}-${KIND}.${RUN_NUMBER}.${RUN_ATTEMPT}.${SHORT_SHA}"
+    ;;
+  workflow_dispatch)
+    if [[ "$RELEASE_FLAG" == "true" ]]; then
+      if [[ "$BRANCH_KIND" != "beta" ]]; then
+        echo "::error::Final releases can only be dispatched from release/X.Y."
+        exit 1
+      fi
+      KIND="release"
+      VERSION="$BASE"
+    else
+      KIND="$BRANCH_KIND"
+      VERSION="${BASE}-${KIND}.${RUN_NUMBER}.${RUN_ATTEMPT}.${SHORT_SHA}"
+    fi
+    ;;
+  *)
+    echo "::error::Unsupported event '$EVENT_NAME'."
+    exit 1
+    ;;
+esac
+
+echo "Target branch: $TARGET"
+echo "Version kind: $KIND"
+echo "Base version: $BASE"
+echo "Build version: $VERSION"
+
+{
+  echo "kind=$KIND"
+  echo "base=$BASE"
+  echo "version=$VERSION"
+} >> "$GITHUB_OUTPUT"

--- a/.github/workflows/baseline-bump.yml
+++ b/.github/workflows/baseline-bump.yml
@@ -1,0 +1,74 @@
+name: Bump package validation baseline
+
+# After a stable vX.Y.Z release ships, raise a pull request pinning
+# <PackageValidationBaselineVersion> in the packable projects to that release, so subsequent
+# builds compare the public API against what consumers actually have and fail on an
+# undeclared breaking change.
+#
+# Prereleases are never tagged and never create a GitHub release, so they never reach here.
+# The version input lets a maintainer re-run the bump against a known good tag if the
+# original run failed or its pull request was closed by mistake.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable version to pin as the baseline (for example 0.5.0). Omit to use the highest stable tag.
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: baseline-bump
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Test baseline bump scripts
+        run: bash .github/actions/baseline-bump/test.sh
+
+      - name: Resolve baseline version
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: bash .github/actions/baseline-bump/resolve.sh
+
+      - name: Configure git identity
+        if: steps.resolve.outputs.skip != 'true'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Bump the release branch
+        if: steps.resolve.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          bash .github/actions/baseline-bump/bump.sh
+          "release/${{ steps.resolve.outputs.major }}.${{ steps.resolve.outputs.minor }}"
+          "${{ steps.resolve.outputs.version }}"
+
+      - name: Bump main
+        if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.bump_main == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          bash .github/actions/baseline-bump/bump.sh
+          main
+          "${{ steps.resolve.outputs.version }}"

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -108,17 +108,43 @@ jobs:
     permissions:
       contents: read
 
+  aot:
+    name: AOT compatibility
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.x
+
+      # Roots the entire public surface of Sigstore and Tuf (see the harness
+      # csproj) so ILC analyses every API, not just those reachable from the
+      # harness entry point. Any IL2xxx/IL3xxx warning fails the build via the
+      # repo-wide TreatWarningsAsErrors.
+      - name: Publish AOT compatibility harness
+        run: dotnet publish tests/Sigstore.AotCompatibility/Sigstore.AotCompatibility.csproj -c Release -r linux-x64 --nologo
+
+      - name: Run published binary
+        run: ./tests/Sigstore.AotCompatibility/bin/Release/net10.0/linux-x64/publish/Sigstore.AotCompatibility
+
   package:
     runs-on: ubuntu-latest
     needs:
       - version
       - test
       - conformance
+      - aot
     if: >-
       ${{
         !cancelled()
         && needs.version.result == 'success'
         && needs.test.result == 'success'
+        && needs.aot.result == 'success'
         && (inputs.skip_conformance || needs.conformance.result == 'success')
       }}
     steps:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -4,11 +4,11 @@ on:
   pull_request:
     branches:
       - main
-      - "release/**"
+      - "release/*"
   push:
     branches:
       - main
-      - "release/**"
+      - "release/*"
   workflow_dispatch:
     inputs:
       release:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -303,6 +303,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -420,6 +421,20 @@ jobs:
             --target "${{ github.sha }}" \
             "artifacts/Sigstore.${PACKAGE_VERSION}.nupkg" \
             "artifacts/Tuf.${PACKAGE_VERSION}.nupkg"
+
+      # A release created with GITHUB_TOKEN does not raise release:published, so the
+      # follow-up baseline bump is dispatched explicitly. The bump is idempotent, so
+      # re-running a stable release does not open a duplicate pull request.
+      - name: Dispatch baseline bump
+        if: needs.version.outputs.kind == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE_VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          gh workflow run baseline-bump.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            --field version="${PACKAGE_VERSION}"
 
   deploy-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,48 +1,80 @@
-name: Build and Deploy
+name: Build and Release
 
 on:
   pull_request:
     branches:
       - main
-      - 'release/*'
+      - "release/**"
   push:
     branches:
       - main
-      - 'release/*'
+      - "release/**"
   workflow_dispatch:
     inputs:
       release:
-        description: 'Produce a GA release (no prerelease suffix). Only valid on release/* branches.'
+        description: Publish a final release from a release/X.Y branch.
         type: boolean
         default: false
       skip_conformance:
-        description: 'Skip conformance tests (use when upstream Sigstore infrastructure is unavailable).'
+        description: Skip conformance tests when upstream infrastructure is unavailable.
         type: boolean
         default: false
 
+concurrency:
+  group: >-
+    build-release-${{
+      github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number)
+      || github.ref_name
+    }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      kind: ${{ steps.version.outputs.kind }}
+      base: ${{ steps.version.outputs.base }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Test version calculation
+        run: bash .github/actions/version/test.sh
+
+      - name: Compute version
+        id: version
+        uses: ./.github/actions/version
+        with:
+          release-flag: ${{ github.event_name == 'workflow_dispatch' && inputs.release || 'false' }}
+
   test:
+    name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-15]
     permissions:
       contents: read
       checks: write
-
     steps:
       - name: Disable CRLF conversion
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
 
@@ -50,10 +82,10 @@ jobs:
         run: dotnet restore Sigstore.slnx
 
       - name: Build
-        run: dotnet build Sigstore.slnx --no-restore
+        run: dotnet build Sigstore.slnx -c Release --no-restore --nologo
 
       - name: Test
-        run: dotnet test Sigstore.slnx --no-build --logger "trx;LogFileName=test-results.trx" --results-directory ./TestResults
+        run: dotnet test Sigstore.slnx -c Release --no-build --nologo --logger "trx;LogFileName=test-results.trx" --results-directory ./TestResults
 
       - name: Publish test results
         uses: dorny/test-reporter@v1
@@ -64,7 +96,7 @@ jobs:
           reporter: dotnet-trx
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: success() || failure()
         with:
           name: test-results-${{ matrix.os }}
@@ -76,103 +108,147 @@ jobs:
     permissions:
       contents: read
 
-  build:
+  package:
     runs-on: ubuntu-latest
-    needs: [test, conformance]
-    if: ${{ !cancelled() && needs.test.result == 'success' && (inputs.skip_conformance || needs.conformance.result == 'success') }}
-    permissions:
-      contents: read
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      base_version: ${{ steps.version.outputs.base_version }}
-      is_release: ${{ steps.version.outputs.is_release }}
-
+    needs:
+      - version
+      - test
+      - conformance
+    if: >-
+      ${{
+        !cancelled()
+        && needs.version.result == 'success'
+        && needs.test.result == 'success'
+        && (inputs.skip_conformance || needs.conformance.result == 'success')
+      }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Generate version
-        id: version
-        uses: ./.github/actions/version
-        with:
-          release: ${{ inputs.release || false }}
+        uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
 
+      - name: Restore
+        run: dotnet restore src/Sigstore/Sigstore.csproj
+
       - name: Pack
+        env:
+          SIGSTORE_VERSION: ${{ needs.version.outputs.version }}
         run: |
           dotnet pack src/Tuf/Tuf.csproj \
             -c Release \
-            -p:PackageVersion=${{ steps.version.outputs.version }} \
-            -o ./artifacts
+            --no-restore \
+            -o artifacts \
+            --nologo
           dotnet pack src/Sigstore/Sigstore.csproj \
             -c Release \
-            -p:PackageVersion=${{ steps.version.outputs.version }} \
-            -o ./artifacts
+            --no-restore \
+            -o artifacts \
+            --nologo
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+      - name: Verify packages
+        env:
+          PACKAGE_VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          for package_id in Tuf Sigstore; do
+            package="artifacts/${package_id}.${PACKAGE_VERSION}.nupkg"
+            test -f "$package" || {
+              echo "Missing package: $package"
+              exit 1
+            }
+
+            contents="$(unzip -Z1 "$package")"
+            for asset in \
+              "README.md" \
+              "THIRD-PARTY-NOTICES.md" \
+              "lib/net10.0/${package_id}.dll" \
+              "lib/net10.0/${package_id}.xml"; do
+              grep -Fxq "$asset" <<<"$contents" || {
+                echo "${package_id} is missing required asset: $asset"
+                exit 1
+              }
+            done
+
+            nuspec="$(unzip -p "$package" "${package_id}.nuspec")"
+            grep -Fq "<version>${PACKAGE_VERSION}</version>" <<<"$nuspec"
+            grep -Fq '<dependency id="BouncyCastle.Cryptography" version="2.7.0"' <<<"$nuspec"
+            if grep -Eq 'NSec|libsodium' <<<"$nuspec"; then
+              echo "${package_id} still references NSec or libsodium."
+              exit 1
+            fi
+          done
+
+          sigstore_nuspec="$(unzip -p "artifacts/Sigstore.${PACKAGE_VERSION}.nupkg" Sigstore.nuspec)"
+          grep -Fq "<dependency id=\"Tuf\" version=\"${PACKAGE_VERSION}\"" <<<"$sigstore_nuspec"
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v5
         with:
-          name: nuget-packages
-          path: ./artifacts/*.nupkg
+          name: nuget-packages-${{ needs.version.outputs.kind }}
+          path: artifacts/*.nupkg
+          if-no-files-found: error
 
-  publish-github:
+  publish-pr:
     runs-on: ubuntu-latest
-    needs: build
-    if: ${{ !cancelled() && needs.build.result == 'success' && needs.build.outputs.is_release != 'true' }}
+    needs:
+      - version
+      - package
+    if: >-
+      needs.version.result == 'success'
+      && needs.package.result == 'success'
+      && needs.version.outputs.kind == 'pr'
+      && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       packages: write
       pull-requests: write
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: nuget-packages
-          path: ./artifacts
+        uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
 
-      - name: Push to GitHub Packages
+      - name: Download packages
+        uses: actions/download-artifact@v5
+        with:
+          name: nuget-packages-pr
+          path: artifacts
+
+      - name: Push preview to GitHub Packages
         run: |
-          dotnet nuget push ./artifacts/*.nupkg \
+          dotnet nuget push artifacts/*.nupkg \
             --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
-            --api-key ${{ secrets.GITHUB_TOKEN }} \
+            --api-key "${{ github.token }}" \
             --skip-duplicate
 
       - name: Post package info to PR
-        if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
-          PACKAGE_VERSION: ${{ needs.build.outputs.version }}
+          PACKAGE_VERSION: ${{ needs.version.outputs.version }}
         run: |
-          # Delete previous package comments
+          set -euo pipefail
+
           gh pr view ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
             --json comments \
-            --jq '.comments[]? | select(.body | startswith("## 📦 Package Published")) | .databaseId' 2>/dev/null | \
+            --jq '.comments[]? | select(.body | startswith("## Package published")) | .databaseId' |
           while IFS= read -r comment_id; do
-            if [ -n "$comment_id" ]; then
+            if [[ -n "$comment_id" ]]; then
               gh api --method DELETE \
                 -H "Accept: application/vnd.github+json" \
-                "/repos/${{ github.repository }}/issues/comments/$comment_id" || true
+                "/repos/${{ github.repository }}/issues/comments/$comment_id"
             fi
           done
 
-          cat > /tmp/pr_comment.md << EOF
-          ## 📦 Package Published
+          cat > pr-comment.md <<EOF
+          ## Package published
 
           **Version:** \`${PACKAGE_VERSION}\`
 
@@ -181,133 +257,151 @@ jobs:
           dotnet add package Tuf --version ${PACKAGE_VERSION}
           \`\`\`
 
-          \`\`\`xml
-          <PackageReference Include="Sigstore" Version="${PACKAGE_VERSION}" />
-          <PackageReference Include="Tuf" Version="${PACKAGE_VERSION}" />
-          \`\`\`
-
-          > Requires [GitHub Packages NuGet source](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry) configured.
-
-          ---
-          *Published at $(date -u '+%Y-%m-%d %H:%M:%S UTC')*
+          > Requires the [GitHub Packages NuGet source](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry).
           EOF
 
-          sed -i 's/^          //' /tmp/pr_comment.md
-
           gh pr comment ${{ github.event.pull_request.number }} \
-            --body-file /tmp/pr_comment.md \
+            --body-file pr-comment.md \
             --repo ${{ github.repository }}
 
-  publish-nuget:
+  publish:
     runs-on: ubuntu-latest
-    needs: build
-    if: ${{ !cancelled() && needs.build.result == 'success' && needs.build.outputs.is_release == 'true' }}
+    needs:
+      - version
+      - package
+    if: >-
+      needs.version.result == 'success'
+      && needs.package.result == 'success'
+      && needs.version.outputs.kind != 'pr'
     environment: production
     permissions:
       contents: write
-      packages: write
       id-token: write
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: nuget-packages
-          path: ./artifacts
-
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
 
-      - name: Push to GitHub Packages
+      - name: Download packages
+        uses: actions/download-artifact@v5
+        with:
+          name: nuget-packages-${{ needs.version.outputs.kind }}
+          path: artifacts
+
+      - name: Skip stale prerelease
+        id: stale
+        if: needs.version.outputs.kind == 'beta'
+        env:
+          BASE_VERSION: ${{ needs.version.outputs.base }}
         run: |
-          dotnet nuget push ./artifacts/*.nupkg \
-            --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
-            --api-key ${{ secrets.GITHUB_TOKEN }} \
-            --skip-duplicate
+          git fetch --tags --force --quiet
+          if git rev-parse -q --verify "refs/tags/v${BASE_VERSION}" >/dev/null; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "v${BASE_VERSION} has shipped; skipping stale beta."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check NuGet.org
+        id: nuget
+        if: steps.stale.outputs.skip != 'true'
+        env:
+          PACKAGE_VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          exists=true
+
+          for package_id in sigstore tuf; do
+            status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+              "https://api.nuget.org/v3-flatcontainer/${package_id}/${PACKAGE_VERSION}/${package_id}.nuspec")"
+            case "$status" in
+              200) ;;
+              404) exists=false ;;
+              *)
+                echo "NuGet.org returned HTTP ${status} for ${package_id}."
+                exit 1
+                ;;
+            esac
+          done
+
+          echo "exists=$exists" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to NuGet.org
-        uses: nuget/login@v1
         id: nuget-login
+        if: steps.stale.outputs.skip != 'true' && steps.nuget.outputs.exists == 'false'
+        uses: NuGet/login@v1
         with:
           user: ${{ secrets.NUGET_USERNAME }}
 
       - name: Push to NuGet.org
+        if: steps.stale.outputs.skip != 'true' && steps.nuget.outputs.exists == 'false'
+        env:
+          PACKAGE_VERSION: ${{ needs.version.outputs.version }}
         run: |
-          dotnet nuget push ./artifacts/*.nupkg \
-            --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} \
-            --source "https://api.nuget.org/v3/index.json" \
+          dotnet nuget push "artifacts/Sigstore.${PACKAGE_VERSION}.nupkg" \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
+            --skip-duplicate
+          dotnet nuget push "artifacts/Tuf.${PACKAGE_VERSION}.nupkg" \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
             --skip-duplicate
 
-      - name: Create git tag and GitHub Release
+      - name: Check GitHub Release
+        id: github-release
+        if: needs.version.outputs.kind == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.build.outputs.base_version }}
+          PACKAGE_VERSION: ${{ needs.version.outputs.version }}
         run: |
-          TAG="v${VERSION}"
-
-          if gh release view "$TAG" --repo ${{ github.repository }} >/dev/null 2>&1; then
-            echo "Release $TAG already exists, skipping"
-            exit 0
+          if gh release view "v${PACKAGE_VERSION}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-          cat > /tmp/release_notes.md << EOF
-          ## Sigstore ${VERSION}
-
-          ### Install
+      - name: Create GitHub Release
+        if: needs.version.outputs.kind == 'release' && steps.github-release.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE_VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          cat > release-notes.md <<EOF
+          ## Sigstore ${PACKAGE_VERSION}
 
           \`\`\`bash
-          dotnet add package Sigstore --version ${VERSION}
-          dotnet add package Tuf --version ${VERSION}
+          dotnet add package Sigstore --version ${PACKAGE_VERSION}
+          dotnet add package Tuf --version ${PACKAGE_VERSION}
           \`\`\`
 
-          ### Links
-          - 📖 [Documentation](https://mitchdenny.github.io/sigstore-dotnet/)
-          - 📦 [Sigstore on NuGet](https://www.nuget.org/packages/Sigstore/${VERSION})
-          - 📦 [Tuf on NuGet](https://www.nuget.org/packages/Tuf/${VERSION})
+          - [Documentation](https://mitchdenny.github.io/sigstore-dotnet/)
+          - [Sigstore on NuGet](https://www.nuget.org/packages/Sigstore/${PACKAGE_VERSION})
+          - [Tuf on NuGet](https://www.nuget.org/packages/Tuf/${PACKAGE_VERSION})
 
-          ---
-          *Released from commit ${{ github.sha }}*
+          Released from commit ${{ github.sha }}.
           EOF
 
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --notes-file /tmp/release_notes.md \
-            --target ${{ github.sha }} \
-            ./artifacts/*.nupkg
-
-      - name: Bump version tags
-        env:
-          VERSION: ${{ needs.build.outputs.base_version }}
-        run: |
-          MAJOR=$(echo "$VERSION" | cut -d'.' -f1)
-          MINOR=$(echo "$VERSION" | cut -d'.' -f2)
-
-          # Tag main with next dev version so main builds target X.(Y+1).0
-          NEXT_MINOR=$((MINOR + 1))
-          DEV_TAG="v${MAJOR}.${NEXT_MINOR}.0-dev"
-
-          # Only create dev tag if it doesn't exist
-          if ! git tag -l "$DEV_TAG" | grep -q "$DEV_TAG"; then
-            # Fetch main branch tip
-            git fetch origin main --quiet
-            git tag "$DEV_TAG" origin/main
-            git push origin "$DEV_TAG"
-            echo "Created dev tag: $DEV_TAG on main"
-          else
-            echo "Dev tag $DEV_TAG already exists, skipping"
-          fi
+          gh release create "v${PACKAGE_VERSION}" \
+            --repo "${{ github.repository }}" \
+            --title "v${PACKAGE_VERSION}" \
+            --notes-file release-notes.md \
+            --target "${{ github.sha }}" \
+            "artifacts/Sigstore.${PACKAGE_VERSION}.nupkg" \
+            "artifacts/Tuf.${PACKAGE_VERSION}.nupkg"
 
   deploy-docs:
     runs-on: ubuntu-latest
-    needs: build
-    if: ${{ !cancelled() && needs.build.result == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: package
+    if: >-
+      needs.package.result == 'success'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
     permissions:
       pages: write
       id-token: write
@@ -317,18 +411,17 @@ jobs:
     concurrency:
       group: pages
       cancel-in-progress: false
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
 
       - name: Install docfx
-        run: dotnet tool install -g docfx
+        run: dotnet tool install --global docfx
 
       - name: Build documentation
         run: docfx docfx.json

--- a/.github/workflows/conformance-drift.yml
+++ b/.github/workflows/conformance-drift.yml
@@ -24,6 +24,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          # The label must exist before it can be applied; `gh issue create --label`
+          # fails outright on an unknown label, which previously caused drift to go
+          # unreported.
+          gh label create "conformance-drift" \
+            --repo "${{ github.repository }}" \
+            --description "Weekly conformance drift detection" \
+            --color "B60205" \
+            --force
+
           existing=$(gh issue list \
             --repo "${{ github.repository }}" \
             --label "conformance-drift" \

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -31,7 +31,7 @@ jobs:
           chmod +x sigstore-conformance-client
 
       - name: Run conformance tests (production)
-        uses: sigstore/sigstore-conformance@9611941d54398f2e3f6383b6f744442a56d2fb2a # v0.0.26
+        uses: sigstore/sigstore-conformance@21533cde107c734ebc153c3e3a24d75fc9811a36 # v0.0.29
         with:
           entrypoint: ${{ github.workspace }}/sigstore-conformance-client
           environment: production
@@ -63,7 +63,7 @@ jobs:
           chmod +x sigstore-conformance-client
 
       - name: Run conformance tests (staging)
-        uses: sigstore/sigstore-conformance@9611941d54398f2e3f6383b6f744442a56d2fb2a # v0.0.26
+        uses: sigstore/sigstore-conformance@21533cde107c734ebc153c3e3a24d75fc9811a36 # v0.0.29
         with:
           entrypoint: ${{ github.workspace }}/sigstore-conformance-client
           environment: staging

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,14 +6,11 @@
     <PackageVersion>$(SigstoreVersion)</PackageVersion>
     <InformationalVersion>$(SigstoreVersion)</InformationalVersion>
     <!--
-      Every package published so far (0.2.0 through 0.5.0) shipped assembly version 1.0.0.0,
-      because the previous build did not flow the package version into the assembly. Deriving
-      the assembly version from the package version now would lower it, which breaks assembly
-      binding for existing consumers and is reported by package validation as CP0003. It stays
-      pinned until a major release deliberately raises it; FileVersion and InformationalVersion
-      carry the real version.
+      AssemblyVersion tracks the package version, with the revision field fixed at zero.
+      Build-specific detail belongs in FileVersion and InformationalVersion, never here: a
+      per-build revision would mint a new assembly identity for every CI run.
     -->
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <AssemblyVersion>$(Version.Split('-')[0]).0</AssemblyVersion>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,15 @@
     <Version>$(SigstoreVersion)</Version>
     <PackageVersion>$(SigstoreVersion)</PackageVersion>
     <InformationalVersion>$(SigstoreVersion)</InformationalVersion>
+    <!--
+      Every package published so far (0.2.0 through 0.5.0) shipped assembly version 1.0.0.0,
+      because the previous build did not flow the package version into the assembly. Deriving
+      the assembly version from the package version now would lower it, which breaks assembly
+      binding for existing consumers and is reported by package validation as CP0003. It stays
+      pinned until a major release deliberately raises it; FileVersion and InformationalVersion
+      carry the real version.
+    -->
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,10 @@
 <Project>
   <PropertyGroup>
+    <SigstoreVersion>$(SIGSTORE_VERSION)</SigstoreVersion>
+    <SigstoreVersion Condition="'$(SigstoreVersion)' == ''">0.0.0-local</SigstoreVersion>
+    <Version>$(SigstoreVersion)</Version>
+    <PackageVersion>$(SigstoreVersion)</PackageVersion>
+    <InformationalVersion>$(SigstoreVersion)</InformationalVersion>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A .NET library for generating and verifying [Sigstore](https://www.sigstore.dev/
 - **RFC 3161 timestamps** — timestamp authority integration
 - **DSSE attestations** — in-toto statement signing and verification
 - **DI-friendly** — constructor injection with sensible defaults
+- **Native AOT ready** — both libraries are trim-safe and AOT-compatible
 
 ## Quick Start
 
@@ -83,6 +84,24 @@ dotnet build Sigstore.slnx
 
 ```bash
 dotnet test Sigstore.slnx
+```
+
+## Native AOT
+
+`Sigstore` and `Tuf` are both trim-safe and compatible with [native AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/).
+They are marked `IsAotCompatible`, use source-generated JSON serialization
+throughout, and contain no runtime reflection.
+
+This is enforced, not assumed. The `tests/Sigstore.AotCompatibility` harness roots
+*both* libraries in full via `TrimmerRootAssembly`, so the AOT compiler analyzes
+their entire public surface rather than only the members a sample app happens to
+call. It runs on every build, and any trim or AOT warning — including one
+originating inside a dependency — fails the build.
+
+To reproduce locally:
+
+```bash
+dotnet publish tests/Sigstore.AotCompatibility -c Release -r linux-x64
 ```
 
 ## Versioning and releases

--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ The build workflow computes one version for both NuGet packages:
 - A manual workflow dispatch with `release` enabled on `release/X.Y` publishes the stable version, creates `vX.Y.Z`, and creates a GitHub Release.
 
 Release branches are long-lived servicing branches and are created manually from `main`.
-Local builds use `0.0.0-local`; set `SIGSTORE_VERSION` to override it. NuGet.org
-publishing uses trusted publishing through the `production` GitHub environment.
+The `0.x` series is closed, so new lines off `main` start at `1.0`. Local builds use
+`0.0.0-local`; set `SIGSTORE_VERSION` to override it. NuGet.org publishing uses trusted
+publishing through the `production` GitHub environment.
 
 ## API compatibility
 
@@ -131,8 +132,12 @@ A deliberate break is declared by regenerating the suppression file:
 dotnet pack src/Sigstore/Sigstore.csproj -c Release -p:ApiCompatGenerateSuppressionFile=true
 ```
 
-The assembly version stays pinned at `1.0.0.0` because every release so far shipped that
-value; raising it is itself a breaking change and belongs to a deliberate major release.
+The assembly version tracks the package version as `Major.Minor.Patch.0`, with prerelease
+labels stripped and the revision field always zero. Build-specific detail belongs in
+`FileVersion` and `InformationalVersion`; a per-build revision would give every CI run a
+distinct assembly identity. Because the published `0.x` packages all shipped assembly
+version `1.0.0.0`, package versions below `1.0.0` would move the assembly version backwards
+and are rejected by package validation as `CP0003` — which is why the `0.x` series is closed.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ Release branches are long-lived servicing branches and are created manually from
 Local builds use `0.0.0-local`; set `SIGSTORE_VERSION` to override it. NuGet.org
 publishing uses trusted publishing through the `production` GitHub environment.
 
+## API compatibility
+
+Packing runs [package validation](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/overview)
+against the last stable release, so a build fails if it removes or changes public API that
+consumers already depend on. The baseline is pinned in a bot-managed block in
+`src/Sigstore/Sigstore.csproj` and `src/Tuf/Tuf.csproj`, and the `Bump package validation
+baseline` workflow raises a pull request moving it forward after each stable release.
+
+A deliberate break is declared by regenerating the suppression file:
+
+```bash
+dotnet pack src/Sigstore/Sigstore.csproj -c Release -p:ApiCompatGenerateSuppressionFile=true
+```
+
+The assembly version stays pinned at `1.0.0.0` because every release so far shipped that
+value; raising it is itself a breaking change and belongs to a deliberate major release.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ dotnet build Sigstore.slnx
 dotnet test Sigstore.slnx
 ```
 
+## Versioning and releases
+
+The build workflow computes one version for both NuGet packages:
+
+- Pull requests targeting `main` or `release/X.Y` produce unique `-pr.*` preview packages.
+- Pushes to `main` publish `-alpha.*` packages for the next minor line.
+- Pushes to `release/X.Y` publish `-beta.*` packages for that line's next patch.
+- A manual workflow dispatch with `release` enabled on `release/X.Y` publishes the stable version, creates `vX.Y.Z`, and creates a GitHub Release.
+
+Release branches are long-lived servicing branches and are created manually from `main`.
+Local builds use `0.0.0-local`; set `SIGSTORE_VERSION` to override it. NuGet.org
+publishing uses trusted publishing through the `production` GitHub environment.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/Sigstore.slnx
+++ b/Sigstore.slnx
@@ -13,6 +13,7 @@
     <Project Path="src/Tuf.Conformance/Tuf.Conformance.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Sigstore.AotCompatibility/Sigstore.AotCompatibility.csproj" />
     <Project Path="tests/Sigstore.Tests/Sigstore.Tests.csproj" />
     <Project Path="tests/Tuf.Tests/Tuf.Tests.csproj" />
   </Folder>

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,42 +4,14 @@ This project incorporates components from the projects listed below.
 
 ---
 
-## NSec.Cryptography
+## BouncyCastle.Cryptography
 
-- **Version:** 25.4.0
+- **Version:** 2.7.0
 - **License:** MIT
-- **Project:** https://github.com/ektrah/nsec
-- **Copyright:** Copyright (c) 2025 Klaus Hartke
+- **Project:** https://github.com/bcgit/bc-csharp
+- **Copyright:** Copyright (c) 2000-2026 Legion of the Bouncy Castle Inc.
 
-NSec.Cryptography is used for Ed25519 signature verification.
-
-NSec itself includes code from libsodium (ISC License), RFC 6234 (Simplified BSD),
-.NET Runtime (MIT), and Steve Thomas's hex/base64 implementation (MIT).
-See the NSec NOTICE file for full details:
-https://github.com/ektrah/nsec/blob/main/NOTICE
-
----
-
-## libsodium
-
-- **Version:** 1.0.20.1
-- **License:** ISC
-- **Project:** https://github.com/jedisct1/libsodium
-- **Copyright:** Copyright (c) 2013-2025 Frank Denis
-
-Transitive native dependency of NSec.Cryptography.
-
-> Permission to use, copy, modify, and/or distribute this software for any
-> purpose with or without fee is hereby granted, provided that the above
-> copyright notice and this permission notice appear in all copies.
->
-> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-> WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-> MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-> ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-> WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-> ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-> OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+BouncyCastle.Cryptography is used for managed Ed25519 signature verification.
 
 ---
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -9,7 +9,7 @@ This project incorporates components from the projects listed below.
 - **Version:** 2.7.0
 - **License:** MIT
 - **Project:** https://github.com/bcgit/bc-csharp
-- **Copyright:** Copyright (c) 2000-2026 Legion of the Bouncy Castle Inc.
+- **Copyright:** Copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc.
 
 BouncyCastle.Cryptography is used for managed Ed25519 signature verification.
 

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -337,7 +337,7 @@ public static class TimestampParser
 | Sigstore Need | .NET API |
 |---------------|----------|
 | ECDSA P-256 key generation | `ECDsa.Create(ECCurve.NamedCurves.nistP256)` |
-| Ed25519 | `System.Security.Cryptography.Ed25519` (.NET 10+) or BouncyCastle fallback |
+| Ed25519 | BouncyCastle `Ed25519PublicKeyParameters` |
 | RSA | `RSA.Create(keySize)` |
 | X.509 cert validation | `X509Chain`, `X509Certificate2` |
 | PKCS#10 CSR | `CertificateRequest` class |

--- a/src/Sigstore/Crypto/Ed25519SignatureVerifier.cs
+++ b/src/Sigstore/Crypto/Ed25519SignatureVerifier.cs
@@ -1,0 +1,44 @@
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math.EC.Rfc8032;
+
+namespace Sigstore;
+
+internal static class Ed25519SignatureVerifier
+{
+    private static ReadOnlySpan<byte> SubjectPublicKeyInfoPrefix =>
+        [0x30, 0x2A, 0x30, 0x05, 0x06, 0x03, 0x2B, 0x65, 0x70, 0x03, 0x21, 0x00];
+
+    public static bool Verify(
+        ReadOnlySpan<byte> publicKey,
+        ReadOnlySpan<byte> message,
+        ReadOnlySpan<byte> signature)
+    {
+        if (signature.Length != Ed25519PrivateKeyParameters.SignatureSize)
+            return false;
+
+        ReadOnlySpan<byte> rawKey;
+        if (publicKey.Length == Ed25519PublicKeyParameters.KeySize)
+        {
+            rawKey = publicKey;
+        }
+        else if (publicKey.Length == SubjectPublicKeyInfoPrefix.Length + Ed25519PublicKeyParameters.KeySize &&
+                 publicKey[..SubjectPublicKeyInfoPrefix.Length].SequenceEqual(SubjectPublicKeyInfoPrefix))
+        {
+            rawKey = publicKey[SubjectPublicKeyInfoPrefix.Length..];
+        }
+        else
+        {
+            return false;
+        }
+
+        try
+        {
+            var key = new Ed25519PublicKeyParameters(rawKey);
+            return key.Verify(Ed25519.Algorithm.Ed25519, null, message, signature);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Sigstore/Sigstore.csproj
+++ b/src/Sigstore/Sigstore.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSec.Cryptography" Version="25.4.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.7.0" />
     <ProjectReference Include="..\Tuf\Tuf.csproj" />
   </ItemGroup>
 

--- a/src/Sigstore/Sigstore.csproj
+++ b/src/Sigstore/Sigstore.csproj
@@ -14,6 +14,10 @@
     <RepositoryUrl>https://github.com/mitchdenny/sigstore-dotnet</RepositoryUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <!-- BEGIN: bot-managed baseline -->
+    <PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>
+    <!-- END: bot-managed baseline -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sigstore/Transparency/CheckpointVerifier.cs
+++ b/src/Sigstore/Transparency/CheckpointVerifier.cs
@@ -164,24 +164,7 @@ public static class CheckpointVerifier
 
     private static bool VerifyEd25519(ReadOnlySpan<byte> publicKey, byte[] message, ReadOnlySpan<byte> signature)
     {
-        ReadOnlySpan<byte> rawKey;
-        if (publicKey.Length == 44)
-        {
-            // SPKI format — extract the 32-byte raw key (skip 12-byte header)
-            rawKey = publicKey.Slice(12);
-        }
-        else if (publicKey.Length == 32)
-        {
-            rawKey = publicKey;
-        }
-        else
-        {
-            return false;
-        }
-
-        var algorithm = NSec.Cryptography.SignatureAlgorithm.Ed25519;
-        var pk = NSec.Cryptography.PublicKey.Import(algorithm, rawKey, NSec.Cryptography.KeyBlobFormat.RawPublicKey);
-        return algorithm.Verify(pk, message, signature);
+        return Ed25519SignatureVerifier.Verify(publicKey, message, signature);
     }
 }
 

--- a/src/Sigstore/Verification/IssuerCandidateIndex.cs
+++ b/src/Sigstore/Verification/IssuerCandidateIndex.cs
@@ -1,0 +1,202 @@
+using System.Formats.Asn1;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Sigstore;
+
+/// <summary>
+/// A lookup, built once per <see cref="TrustedRoot"/>, from a leaf certificate's issuer name and
+/// authority key identifier to the certificate authorities that could have issued it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A precertificate SCT commits to a hash of the issuing certificate's public key, so SCT
+/// verification needs that exact certificate. Selecting it by subject name alone is not safe: an
+/// authority that rotates its key keeps its subject name, so a trusted root can legitimately hold
+/// several distinct authorities sharing one name. Picking the first name match then reconstructs
+/// the signed data with the wrong key and every SCT appears invalid.
+/// </para>
+/// <para>
+/// Resolving an issuer therefore has to compare subject names and key identifiers, which requires
+/// decoding every candidate certificate. Doing that per verification costs time proportional to the
+/// size of the trusted root, so the decoded form is cached here against the trusted root instance
+/// and each subsequent lookup is a dictionary probe. The cache assumes a trusted root is not
+/// mutated after construction, which holds for every instance this library produces.
+/// </para>
+/// </remarks>
+internal sealed class IssuerCandidateIndex
+{
+    // OID of the X.509 authority key identifier extension (RFC 5280 4.2.1.1).
+    private const string AuthorityKeyIdentifierOid = "2.5.29.35";
+    // OID of the X.509 subject key identifier extension (RFC 5280 4.2.1.2).
+    private const string SubjectKeyIdentifierOid = "2.5.29.14";
+
+    private static readonly ConditionalWeakTable<TrustedRoot, IssuerCandidateIndex> Cache = new();
+
+    private readonly Dictionary<string, SubjectGroup> _bySubject = [];
+
+    private IssuerCandidateIndex(TrustedRoot trustRoot)
+    {
+        foreach (var authority in trustRoot.CertificateAuthorities)
+        {
+            foreach (var certificateBytes in authority.CertificateChain)
+            {
+                string subjectKey;
+                ReadOnlyMemory<byte>? subjectKeyId;
+
+                try
+                {
+                    using var certificate = X509CertificateLoader.LoadCertificate(certificateBytes.Span);
+                    subjectKey = Convert.ToHexString(certificate.SubjectName.RawData);
+                    subjectKeyId = GetSubjectKeyIdentifier(certificate);
+                }
+                catch (CryptographicException)
+                {
+                    continue;
+                }
+
+                if (!_bySubject.TryGetValue(subjectKey, out var group))
+                {
+                    group = new SubjectGroup();
+                    _bySubject[subjectKey] = group;
+                }
+
+                group.All.Add(certificateBytes);
+
+                if (subjectKeyId is { } identifier)
+                {
+                    var identifierKey = Convert.ToHexString(identifier.Span);
+                    if (!group.BySubjectKeyIdentifier.TryGetValue(identifierKey, out var matches))
+                    {
+                        matches = [];
+                        group.BySubjectKeyIdentifier[identifierKey] = matches;
+                    }
+
+                    matches.Add(certificateBytes);
+                }
+                else
+                {
+                    group.WithoutSubjectKeyIdentifier.Add(certificateBytes);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the index for <paramref name="trustRoot"/>, building it on first use.
+    /// </summary>
+    /// <param name="trustRoot">The trusted root to index.</param>
+    public static IssuerCandidateIndex For(TrustedRoot trustRoot) =>
+        Cache.GetValue(trustRoot, static root => new IssuerCandidateIndex(root));
+
+    /// <summary>
+    /// Collects the certificates that may have issued <paramref name="leafCert"/>, most likely first.
+    /// </summary>
+    /// <remarks>
+    /// When the leaf names its issuer's key and the trusted root holds a certificate publishing that
+    /// key identifier, authorities publishing a different one cannot have issued the leaf and are
+    /// excluded. Authorities that omit the extension cannot be ruled out, so they are retained as
+    /// fallbacks, as are all name matches when the leaf itself omits the extension.
+    /// </remarks>
+    /// <param name="leafCert">The certificate whose issuer is being resolved.</param>
+    /// <param name="owned">Receives the certificates loaded here, which the caller must dispose.</param>
+    public List<X509Certificate2> Resolve(X509Certificate2 leafCert, List<X509Certificate2> owned)
+    {
+        if (!_bySubject.TryGetValue(Convert.ToHexString(leafCert.IssuerName.RawData), out var group))
+            return [];
+
+        List<ReadOnlyMemory<byte>> selected;
+
+        if (GetAuthorityKeyIdentifier(leafCert) is { } authorityKeyId &&
+            group.BySubjectKeyIdentifier.TryGetValue(Convert.ToHexString(authorityKeyId.Span), out var exact))
+        {
+            selected = group.WithoutSubjectKeyIdentifier.Count == 0
+                ? exact
+                : [.. exact, .. group.WithoutSubjectKeyIdentifier];
+        }
+        else
+        {
+            selected = group.All;
+        }
+
+        var candidates = new List<X509Certificate2>(selected.Count);
+
+        foreach (var certificateBytes in selected)
+        {
+            X509Certificate2 certificate;
+            try
+            {
+                certificate = X509CertificateLoader.LoadCertificate(certificateBytes.Span);
+            }
+            catch (CryptographicException)
+            {
+                continue;
+            }
+
+            owned.Add(certificate);
+            candidates.Add(certificate);
+        }
+
+        return candidates;
+    }
+
+    private static ReadOnlyMemory<byte>? GetAuthorityKeyIdentifier(X509Certificate2 cert)
+    {
+        var extension = cert.Extensions[AuthorityKeyIdentifierOid];
+        if (extension == null)
+            return null;
+
+        try
+        {
+            // Unlike the subject key identifier extension, this type's byte[] constructor decodes
+            // the extension rather than treating the bytes as an identifier.
+            return new X509AuthorityKeyIdentifierExtension(extension.RawData, extension.Critical)
+                .KeyIdentifier;
+        }
+        catch (AsnContentException)
+        {
+            return null;
+        }
+        catch (CryptographicException)
+        {
+            return null;
+        }
+    }
+
+    private static ReadOnlyMemory<byte>? GetSubjectKeyIdentifier(X509Certificate2 cert)
+    {
+        var extension = cert.Extensions[SubjectKeyIdentifierOid];
+        if (extension == null)
+            return null;
+
+        try
+        {
+            // The extension value is a bare OCTET STRING (RFC 5280 4.2.1.2). It is decoded here
+            // rather than through X509SubjectKeyIdentifierExtension, whose byte[] constructor would
+            // treat the encoded value as the identifier itself and leave its DER header in place,
+            // preventing it from ever matching an authority key identifier.
+            return new AsnReader(extension.RawData, AsnEncodingRules.DER).ReadOctetString();
+        }
+        catch (AsnContentException)
+        {
+            return null;
+        }
+        catch (CryptographicException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// The certificates in a trusted root that share one subject name.
+    /// </summary>
+    private sealed class SubjectGroup
+    {
+        public List<ReadOnlyMemory<byte>> All { get; } = [];
+
+        public Dictionary<string, List<ReadOnlyMemory<byte>>> BySubjectKeyIdentifier { get; } = [];
+
+        public List<ReadOnlyMemory<byte>> WithoutSubjectKeyIdentifier { get; } = [];
+    }
+}

--- a/src/Sigstore/Verification/SctVerifier.cs
+++ b/src/Sigstore/Verification/SctVerifier.cs
@@ -220,17 +220,7 @@ internal static class SctVerifier
 
     private static bool VerifyEd25519Sct(byte[] data, ReadOnlySpan<byte> signature, ReadOnlyMemory<byte> publicKeyBytes)
     {
-        ReadOnlySpan<byte> rawKey;
-        if (publicKeyBytes.Length == 44)
-            rawKey = publicKeyBytes.Span.Slice(12);
-        else if (publicKeyBytes.Length == 32)
-            rawKey = publicKeyBytes.Span;
-        else
-            return false;
-
-        var algorithm = NSec.Cryptography.SignatureAlgorithm.Ed25519;
-        var pk = NSec.Cryptography.PublicKey.Import(algorithm, rawKey, NSec.Cryptography.KeyBlobFormat.RawPublicKey);
-        return algorithm.Verify(pk, data, signature);
+        return Ed25519SignatureVerifier.Verify(publicKeyBytes.Span, data, signature);
     }
 
     /// <summary>

--- a/src/Sigstore/Verification/SctVerifier.cs
+++ b/src/Sigstore/Verification/SctVerifier.cs
@@ -19,10 +19,18 @@ internal static class SctVerifier
     /// Verifies that at least one SCT in the leaf certificate is signed by a
     /// CT log key from the trusted root.
     /// </summary>
+    /// <param name="leafCert">The certificate whose embedded SCTs are verified.</param>
+    /// <param name="issuerCandidates">
+    /// Certificates that may have issued <paramref name="leafCert"/>. A precertificate SCT commits
+    /// to a hash of the issuer's public key, so the signed data can only be reconstructed with the
+    /// real issuer. Callers cannot always identify it unambiguously, so every plausible issuer is
+    /// tried before the SCT is rejected.
+    /// </param>
+    /// <param name="ctLogs">The CT logs from the trusted root.</param>
     /// <returns>True if at least one SCT verifies, or if there are no CT logs in the trusted root.</returns>
     public static bool VerifyScts(
         X509Certificate2 leafCert,
-        X509Certificate2? issuerCert,
+        IReadOnlyList<X509Certificate2> issuerCandidates,
         IReadOnlyList<TransparencyLogInfo> ctLogs)
     {
         // If no CT logs configured, SCT verification is not required
@@ -49,8 +57,18 @@ internal static class SctVerifier
             if (!ctLogsByLogId.TryGetValue(logIdHex, out var ctLog))
                 continue; // Unknown log — skip this SCT
 
-            if (VerifySctSignature(sct, ctLog, leafCert, issuerCert))
-                return true;
+            if (issuerCandidates.Count == 0)
+            {
+                if (VerifySctSignature(sct, ctLog, leafCert, null))
+                    return true;
+                continue;
+            }
+
+            foreach (var issuerCert in issuerCandidates)
+            {
+                if (VerifySctSignature(sct, ctLog, leafCert, issuerCert))
+                    return true;
+            }
         }
 
         return false; // No SCT could be verified

--- a/src/Sigstore/Verification/SigstoreVerifier.cs
+++ b/src/Sigstore/Verification/SigstoreVerifier.cs
@@ -1,3 +1,4 @@
+using System.Formats.Asn1;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -266,36 +267,18 @@ public sealed class SigstoreVerifier
             // Step 2b: Verify SCTs if CT logs are configured
             if (trustRoot.CtLogs.Count > 0)
             {
-                // Find the issuer cert from intermediates, cert chain, or trusted root CAs
-                X509Certificate2? issuerCert = null;
-                if (intermediates is { Count: > 0 })
+                var ownedIssuers = new List<X509Certificate2>();
+                try
                 {
-                    issuerCert = intermediates[0];
+                    var issuerCandidates = ResolveIssuerCandidates(leafCert, intermediates, trustRoot, ownedIssuers);
+                    if (!SctVerifier.VerifyScts(leafCert, issuerCandidates, trustRoot.CtLogs))
+                        return Fail("No valid Signed Certificate Timestamp (SCT) found for any configured CT log.");
                 }
-                else
+                finally
                 {
-                    // Try to find issuer in trusted root certificate authorities
-                    foreach (var ca in trustRoot.CertificateAuthorities)
-                    {
-                        foreach (var caCertBytes in ca.CertificateChain)
-                        {
-                            try
-                            {
-                                using var caCert = X509CertificateLoader.LoadCertificate(caCertBytes.Span);
-                                if (leafCert.IssuerName.RawData.AsSpan().SequenceEqual(caCert.SubjectName.RawData))
-                                {
-                                    issuerCert = X509CertificateLoader.LoadCertificate(caCertBytes.Span);
-                                    break;
-                                }
-                            }
-                            catch { }
-                        }
-                        if (issuerCert != null) break;
-                    }
+                    foreach (var issuer in ownedIssuers)
+                        issuer.Dispose();
                 }
-
-                if (!SctVerifier.VerifyScts(leafCert, issuerCert, trustRoot.CtLogs))
-                    return Fail("No valid Signed Certificate Timestamp (SCT) found for any configured CT log.");
             }
 
             // Step 3: Establish signature time
@@ -1050,6 +1033,126 @@ public sealed class SigstoreVerifier
 
         return true;
     }
+
+    // OID of the X.509 authority key identifier extension (RFC 5280 §4.2.1.1).
+    private const string AuthorityKeyIdentifierOid = "2.5.29.35";
+    // OID of the X.509 subject key identifier extension (RFC 5280 §4.2.1.2).
+    private const string SubjectKeyIdentifierOid = "2.5.29.14";
+
+    /// <summary>
+    /// Collects the certificates that may have issued <paramref name="leafCert"/>, most likely first.
+    /// </summary>
+    /// <remarks>
+    /// A precertificate SCT commits to a hash of the issuing certificate's public key, so SCT
+    /// verification needs that exact certificate. Selecting it by subject name alone is not safe:
+    /// a certificate authority that rotates its key keeps its subject name, so a trusted root can
+    /// legitimately hold several distinct authorities sharing one name. Picking the first name match
+    /// then silently reconstructs the signed data with the wrong key and every SCT appears invalid.
+    /// Candidates whose subject key identifier matches the leaf's authority key identifier are
+    /// returned first, and the remaining name matches are retained as fallbacks so certificates that
+    /// omit those extensions still verify.
+    /// </remarks>
+    /// <param name="leafCert">The certificate whose issuer is being resolved.</param>
+    /// <param name="intermediates">Intermediate certificates supplied by the bundle, if any.</param>
+    /// <param name="trustRoot">The trusted root supplying the certificate authorities to search.</param>
+    /// <param name="owned">Receives the certificates loaded here, which the caller must dispose.</param>
+    internal static List<X509Certificate2> ResolveIssuerCandidates(
+        X509Certificate2 leafCert,
+        X509Certificate2Collection? intermediates,
+        TrustedRoot trustRoot,
+        List<X509Certificate2> owned)
+    {
+        // A bundle-supplied chain names its issuer directly, so there is nothing to disambiguate.
+        if (intermediates is { Count: > 0 })
+            return [intermediates[0]];
+
+        var authorityKeyId = GetAuthorityKeyIdentifier(leafCert);
+
+        var preferred = new List<X509Certificate2>();
+        var fallback = new List<X509Certificate2>();
+
+        foreach (var ca in trustRoot.CertificateAuthorities)
+        {
+            foreach (var caCertBytes in ca.CertificateChain)
+            {
+                X509Certificate2 caCert;
+                try
+                {
+                    caCert = X509CertificateLoader.LoadCertificate(caCertBytes.Span);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (!leafCert.IssuerName.RawData.AsSpan().SequenceEqual(caCert.SubjectName.RawData))
+                {
+                    caCert.Dispose();
+                    continue;
+                }
+
+                owned.Add(caCert);
+
+                var subjectKeyId = GetSubjectKeyIdentifier(caCert);
+
+                if (authorityKeyId is { } akid && subjectKeyId is { } skid && akid.Span.SequenceEqual(skid.Span))
+                    preferred.Add(caCert);
+                else
+                    fallback.Add(caCert);
+            }
+        }
+
+        preferred.AddRange(fallback);
+        return preferred;
+    }
+
+    private static ReadOnlyMemory<byte>? GetAuthorityKeyIdentifier(X509Certificate2 cert)
+    {
+        var extension = cert.Extensions[AuthorityKeyIdentifierOid];
+        if (extension == null)
+            return null;
+
+        try
+        {
+            // Unlike the subject key identifier extension, this type's byte[] constructor decodes
+            // the extension rather than treating the bytes as an identifier.
+            return new X509AuthorityKeyIdentifierExtension(extension.RawData, extension.Critical)
+                .KeyIdentifier;
+        }
+        catch (AsnContentException)
+        {
+            return null;
+        }
+        catch (CryptographicException)
+        {
+            return null;
+        }
+    }
+
+    private static ReadOnlyMemory<byte>? GetSubjectKeyIdentifier(X509Certificate2 cert)
+    {
+        var extension = cert.Extensions[SubjectKeyIdentifierOid];
+        if (extension == null)
+            return null;
+
+        try
+        {
+            // The extension value is a bare OCTET STRING (RFC 5280 §4.2.1.2). It is decoded here
+            // rather than through X509SubjectKeyIdentifierExtension, whose byte[] constructor would
+            // treat the encoded value as the identifier itself and leave its DER header in place,
+            // preventing it from ever matching an authority key identifier.
+            return new AsnReader(extension.RawData, AsnEncodingRules.DER).ReadOctetString();
+        }
+        catch (AsnContentException)
+        {
+            return null;
+        }
+        catch (CryptographicException)
+        {
+            return null;
+        }
+    }
+
 
     /// <summary>
     /// The <c>(kind, apiVersion)</c> transparency log entry schemas this client knows how

--- a/src/Sigstore/Verification/SigstoreVerifier.cs
+++ b/src/Sigstore/Verification/SigstoreVerifier.cs
@@ -1044,19 +1044,41 @@ public sealed class SigstoreVerifier
         // Cross-verify tlog entry body against the bundle contents
         if (entry.Body != null)
         {
-            if (!CrossVerifyTlogBody(entry.Body, bundle, leafCertBytes))
+            if (!CrossVerifyTlogBody(entry, bundle, leafCertBytes))
                 return false;
         }
 
         return true;
     }
 
-    private static bool CrossVerifyTlogBody(string body, SigstoreBundle bundle, ReadOnlyMemory<byte> leafCertBytes)
+    /// <summary>
+    /// The <c>(kind, apiVersion)</c> transparency log entry schemas this client knows how
+    /// to cross-check against a bundle. Anything outside this set is rejected.
+    /// </summary>
+    /// <remarks>
+    /// Cross-verification is what binds the log entry to the artifact the bundle ships.
+    /// Every field in an entry body is read by name, so an entry whose schema we do not
+    /// recognise would match none of those names, skip every check, and be reported as
+    /// verified without anything having been verified — the log entry would be accepted
+    /// purely because it was well-formed JSON. Failing closed on unrecognised schemas
+    /// keeps "we checked it and it matched" distinct from "we had no idea what to check",
+    /// and matches sigstore-go, which rejects unsupported entry types outright.
+    /// </remarks>
+    private static readonly HashSet<(string Kind, string ApiVersion)> SupportedTlogEntrySchemas =
+    [
+        ("hashedrekord", "0.0.1"),
+        ("hashedrekord", "0.0.2"),
+        ("dsse", "0.0.1"),
+        ("dsse", "0.0.2"),
+        ("intoto", "0.0.2"),
+    ];
+
+    internal static bool CrossVerifyTlogBody(TransparencyLogEntry entry, SigstoreBundle bundle, ReadOnlyMemory<byte> leafCertBytes)
     {
         byte[] bodyBytes;
         try
         {
-            bodyBytes = Convert.FromBase64String(body);
+            bodyBytes = Convert.FromBase64String(entry.Body!);
         }
         catch
         {
@@ -1074,54 +1096,84 @@ public sealed class SigstoreVerifier
         }
 
         var root = doc.RootElement;
-        var kind = root.GetProperty("kind").GetString();
 
-        if (kind == "hashedrekord")
+        // Read the schema identifiers defensively: a body missing either one cannot be
+        // cross-checked, so it must not count as a verified entry.
+        if (!root.TryGetProperty("kind", out var kindElem) || kindElem.ValueKind != JsonValueKind.String ||
+            !root.TryGetProperty("apiVersion", out var versionElem) || versionElem.ValueKind != JsonValueKind.String)
         {
-            return CrossVerifyHashedrekord(root.GetProperty("spec"), bundle, leafCertBytes);
-        }
-        else if (kind == "dsse" || kind == "intoto")
-        {
-            return CrossVerifyDsse(root.GetProperty("spec"), bundle, leafCertBytes);
+            return false;
         }
 
-        // Unknown kind — allow
-        return true;
+        var kind = kindElem.GetString()!;
+        var apiVersion = versionElem.GetString()!;
+
+        // The bundle advertises the entry's kind/version out of band, alongside the body.
+        // If the two disagree, the entry is not the one the bundle claims it is, and the
+        // out-of-band value could steer other logic (such as Rekor v1/v2 detection) away
+        // from what the signed body actually contains.
+        if ((entry.Kind != null && entry.Kind != kind) ||
+            (entry.KindVersion != null && entry.KindVersion != apiVersion))
+        {
+            return false;
+        }
+
+        if (!SupportedTlogEntrySchemas.Contains((kind, apiVersion)))
+            return false;
+
+        if (!root.TryGetProperty("spec", out var spec) || spec.ValueKind != JsonValueKind.Object)
+            return false;
+
+        // Dispatch on the declared version and require that version's shape to be present.
+        // Selecting the handler by sniffing for a shape instead would let an entry that
+        // declares a version it does not match fall through to a handler that checks
+        // nothing.
+        return (kind, apiVersion) switch
+        {
+            ("hashedrekord", "0.0.1") =>
+                CrossVerifyHashedrekord(spec, bundle, leafCertBytes),
+            ("hashedrekord", "0.0.2") =>
+                spec.TryGetProperty("hashedRekordV002", out var v002) &&
+                CrossVerifyHashedrekordV002(v002, bundle, leafCertBytes),
+            ("dsse", "0.0.2") =>
+                spec.TryGetProperty("dsseV002", out var dsseV002) &&
+                bundle.DsseEnvelope != null &&
+                CrossVerifyDsseV002(dsseV002, bundle, leafCertBytes),
+            ("dsse", "0.0.1") or ("intoto", "0.0.2") =>
+                CrossVerifyDsse(spec, bundle, leafCertBytes),
+            _ => false,
+        };
     }
 
+    /// <summary>
+    /// Cross-verifies a Rekor v1 <c>hashedrekord</c> (v0.0.1) entry against the bundle.
+    /// </summary>
     private static bool CrossVerifyHashedrekord(JsonElement spec, SigstoreBundle bundle, ReadOnlyMemory<byte> leafCertBytes)
     {
-        // Rekor v2 nests the entry under `hashedRekordV002` and uses a different
-        // shape to v1 (base64 digest rather than a hex `data.hash.value`, and a raw
-        // DER `verifier.x509Certificate` rather than a PEM `publicKey`).
-        if (spec.TryGetProperty("hashedRekordV002", out var v002))
+        // `signature` is required by the v0.0.1 schema and carries both bindings we
+        // cross-check, so an entry without it cannot be verified against the bundle.
+        if (!spec.TryGetProperty("signature", out var sigElem))
+            return false;
+
+        if (sigElem.TryGetProperty("content", out var sigContent))
         {
-            return CrossVerifyHashedrekordV002(v002, bundle, leafCertBytes);
+            var expectedSig = Convert.FromBase64String(sigContent.GetString()!);
+            // DSSE bundles store signature in the envelope, not MessageSignature
+            var bundleSig = bundle.MessageSignature?.Signature
+                ?? bundle.DsseEnvelope?.Signatures.FirstOrDefault()?.Sig
+                ?? default(ReadOnlyMemory<byte>);
+            if (!expectedSig.AsSpan().SequenceEqual(bundleSig.Span))
+                return false;
         }
 
-        // Verify signature matches
-        if (spec.TryGetProperty("signature", out var sigElem))
+        // Verify certificate matches
+        if (sigElem.TryGetProperty("publicKey", out var pubKeyElem) &&
+            pubKeyElem.TryGetProperty("content", out var certContent))
         {
-            if (sigElem.TryGetProperty("content", out var sigContent))
-            {
-                var expectedSig = Convert.FromBase64String(sigContent.GetString()!);
-                // DSSE bundles store signature in the envelope, not MessageSignature
-                var bundleSig = bundle.MessageSignature?.Signature
-                    ?? bundle.DsseEnvelope?.Signatures.FirstOrDefault()?.Sig
-                    ?? default(ReadOnlyMemory<byte>);
-                if (!expectedSig.AsSpan().SequenceEqual(bundleSig.Span))
-                    return false;
-            }
-
-            // Verify certificate matches
-            if (sigElem.TryGetProperty("publicKey", out var pubKeyElem) &&
-                pubKeyElem.TryGetProperty("content", out var certContent))
-            {
-                var expectedCertPem = Encoding.UTF8.GetString(Convert.FromBase64String(certContent.GetString()!));
-                var expectedCertDer = ConvertPemToDer(expectedCertPem);
-                if (expectedCertDer != null && !expectedCertDer.AsSpan().SequenceEqual(leafCertBytes.Span))
-                    return false;
-            }
+            var expectedCertPem = Encoding.UTF8.GetString(Convert.FromBase64String(certContent.GetString()!));
+            var expectedCertDer = ConvertPemToDer(expectedCertPem);
+            if (expectedCertDer != null && !expectedCertDer.AsSpan().SequenceEqual(leafCertBytes.Span))
+                return false;
         }
 
         // Verify artifact hash matches
@@ -1304,15 +1356,10 @@ public sealed class SigstoreVerifier
         if (bundle.DsseEnvelope == null)
             return false;
 
-        // Handle three formats:
-        // 1. dsseV002: spec.dsseV002.{signatures, payloadHash} (Rekor v2)
-        // 2. intoto: spec.content.{envelope, payloadHash} (Rekor v1)
-        // 3. dsse v0.0.1: spec.{signatures, payloadHash} (Rekor v1)
-
-        if (spec.TryGetProperty("dsseV002", out var dsseV002))
-        {
-            return CrossVerifyDsseV002(dsseV002, bundle, leafCertBytes);
-        }
+        // Handle the two Rekor v1 envelope shapes:
+        // 1. intoto v0.0.2: spec.content.{envelope, payloadHash}
+        // 2. dsse v0.0.1:   spec.{signatures, payloadHash}
+        // The Rekor v2 dsseV002 shape is dispatched by version in CrossVerifyTlogBody.
 
         JsonElement sigSource;
         JsonElement? payloadHashElem = null;

--- a/src/Sigstore/Verification/SigstoreVerifier.cs
+++ b/src/Sigstore/Verification/SigstoreVerifier.cs
@@ -1140,7 +1140,7 @@ public sealed class SigstoreVerifier
                 bundle.DsseEnvelope != null &&
                 CrossVerifyDsseV002(dsseV002, bundle, leafCertBytes),
             ("dsse", "0.0.1") or ("intoto", "0.0.2") =>
-                CrossVerifyDsse(spec, bundle, leafCertBytes),
+                CrossVerifyDsse(kind, spec, bundle, leafCertBytes),
             _ => false,
         };
     }
@@ -1150,37 +1150,35 @@ public sealed class SigstoreVerifier
     /// </summary>
     private static bool CrossVerifyHashedrekord(JsonElement spec, SigstoreBundle bundle, ReadOnlyMemory<byte> leafCertBytes)
     {
-        // `signature` is required by the v0.0.1 schema and carries both bindings we
-        // cross-check, so an entry without it cannot be verified against the bundle.
+        // Every field read below is required by the v0.0.1 schema. Treating an absent
+        // field as "nothing to check" would let a body opt out of the binding simply by
+        // omitting it, so a missing field is a verification failure.
         if (!spec.TryGetProperty("signature", out var sigElem))
             return false;
 
-        if (sigElem.TryGetProperty("content", out var sigContent))
-        {
-            var expectedSig = Convert.FromBase64String(sigContent.GetString()!);
-            // DSSE bundles store signature in the envelope, not MessageSignature
-            var bundleSig = bundle.MessageSignature?.Signature
-                ?? bundle.DsseEnvelope?.Signatures.FirstOrDefault()?.Sig
-                ?? default(ReadOnlyMemory<byte>);
-            if (!expectedSig.AsSpan().SequenceEqual(bundleSig.Span))
-                return false;
-        }
-
-        // Verify certificate matches
-        if (sigElem.TryGetProperty("publicKey", out var pubKeyElem) &&
-            pubKeyElem.TryGetProperty("content", out var certContent))
-        {
-            var expectedCertPem = Encoding.UTF8.GetString(Convert.FromBase64String(certContent.GetString()!));
-            var expectedCertDer = ConvertPemToDer(expectedCertPem);
-            if (expectedCertDer != null && !expectedCertDer.AsSpan().SequenceEqual(leafCertBytes.Span))
-                return false;
-        }
-
-        // Verify artifact hash matches
-        if (!CrossVerifyHashedrekordArtifactHash(spec, bundle))
+        if (!TryGetBase64(sigElem, "content", out var expectedSig))
             return false;
 
-        return true;
+        // DSSE bundles store signature in the envelope, not MessageSignature
+        var bundleSig = bundle.MessageSignature?.Signature
+            ?? bundle.DsseEnvelope?.Signatures.FirstOrDefault()?.Sig
+            ?? default(ReadOnlyMemory<byte>);
+        if (!expectedSig.AsSpan().SequenceEqual(bundleSig.Span))
+            return false;
+
+        // Verify certificate matches
+        if (!sigElem.TryGetProperty("publicKey", out var pubKeyElem) ||
+            !TryGetBase64(pubKeyElem, "content", out var certPemBytes))
+        {
+            return false;
+        }
+
+        var expectedCertDer = ConvertPemToDer(Encoding.UTF8.GetString(certPemBytes));
+        if (expectedCertDer == null || !expectedCertDer.AsSpan().SequenceEqual(leafCertBytes.Span))
+            return false;
+
+        // Verify artifact hash matches
+        return CrossVerifyHashedrekordArtifactHash(spec, bundle);
     }
 
     /// <summary>
@@ -1202,89 +1200,60 @@ public sealed class SigstoreVerifier
     /// </remarks>
     private static bool CrossVerifyHashedrekordV002(JsonElement v002, SigstoreBundle bundle, ReadOnlyMemory<byte> leafCertBytes)
     {
-        if (v002.TryGetProperty("signature", out var sigElem))
-        {
-            if (sigElem.TryGetProperty("content", out var sigContent))
-            {
-                byte[] expectedSig;
-                try
-                {
-                    expectedSig = Convert.FromBase64String(sigContent.GetString()!);
-                }
-                catch
-                {
-                    return false;
-                }
+        // signature, data.digest and data.algorithm are all required by the v0.0.2
+        // schema; an entry that omits any of them cannot be bound to the bundle.
+        if (!v002.TryGetProperty("signature", out var sigElem))
+            return false;
 
-                var bundleSig = bundle.MessageSignature?.Signature
-                    ?? bundle.DsseEnvelope?.Signatures.FirstOrDefault()?.Sig
-                    ?? default(ReadOnlyMemory<byte>);
+        if (!TryGetBase64(sigElem, "content", out var expectedSig))
+            return false;
 
-                if (!expectedSig.AsSpan().SequenceEqual(bundleSig.Span))
-                    return false;
-            }
+        var bundleSig = bundle.MessageSignature?.Signature
+            ?? bundle.DsseEnvelope?.Signatures.FirstOrDefault()?.Sig
+            ?? default(ReadOnlyMemory<byte>);
 
-            if (sigElem.TryGetProperty("verifier", out var verifier) &&
-                verifier.TryGetProperty("x509Certificate", out var x509) &&
-                x509.TryGetProperty("rawBytes", out var rawBytes))
-            {
-                byte[] expectedCertDer;
-                try
-                {
-                    expectedCertDer = Convert.FromBase64String(rawBytes.GetString()!);
-                }
-                catch
-                {
-                    return false;
-                }
+        if (!expectedSig.AsSpan().SequenceEqual(bundleSig.Span))
+            return false;
 
-                if (!expectedCertDer.AsSpan().SequenceEqual(leafCertBytes.Span))
-                    return false;
-            }
-        }
-
-        if (!v002.TryGetProperty("data", out var dataElem) ||
-            !dataElem.TryGetProperty("digest", out var digestElem))
-        {
-            return true;
-        }
-
-        byte[] expectedDigest;
-        try
-        {
-            expectedDigest = Convert.FromBase64String(digestElem.GetString()!);
-        }
-        catch
+        if (!sigElem.TryGetProperty("verifier", out var verifier) ||
+            !verifier.TryGetProperty("x509Certificate", out var x509) ||
+            !TryGetBase64(x509, "rawBytes", out var expectedCertDer))
         {
             return false;
         }
 
-        var algorithm = dataElem.TryGetProperty("algorithm", out var algElem)
-            ? algElem.GetString()
-            : "SHA2_256";
-        var mapped = MapRekorV2HashAlgorithm(algorithm);
+        if (!expectedCertDer.AsSpan().SequenceEqual(leafCertBytes.Span))
+            return false;
+
+        if (!v002.TryGetProperty("data", out var dataElem) ||
+            !TryGetBase64(dataElem, "digest", out var expectedDigest))
+        {
+            return false;
+        }
+
+        var mapped = MapRekorV2HashAlgorithm(
+            dataElem.TryGetProperty("algorithm", out var algElem) ? algElem.GetString() : null);
+
+        if (mapped == HashAlgorithmType.Unspecified)
+            return false;
 
         if (bundle.DsseEnvelope is { } envelope)
         {
-            // Only SHA-256 PAE digests are defined for this entry type today; a
-            // different algorithm is not something we can cross-check.
-            if (mapped != HashAlgorithmType.Sha256)
-                return true;
-
-            var computed = SHA256.HashData(ComputeDssePae(envelope));
-            return computed.AsSpan().SequenceEqual(expectedDigest);
+            var computed = ComputeHash(mapped, ComputeDssePae(envelope));
+            return computed != null && computed.AsSpan().SequenceEqual(expectedDigest);
         }
 
-        if (bundle.MessageSignature?.MessageDigest is { } messageDigest &&
-            messageDigest.Algorithm != HashAlgorithmType.Unspecified)
+        if (bundle.MessageSignature?.MessageDigest is not { } messageDigest ||
+            messageDigest.Algorithm == HashAlgorithmType.Unspecified)
         {
-            if (mapped != messageDigest.Algorithm)
-                return true;
-
-            return messageDigest.Digest.Span.SequenceEqual(expectedDigest);
+            return false;
         }
 
-        return true;
+        // The digests are only comparable when they were produced by the same algorithm.
+        if (mapped != messageDigest.Algorithm)
+            return false;
+
+        return messageDigest.Digest.Span.SequenceEqual(expectedDigest);
     }
 
     private static HashAlgorithmType MapRekorV2HashAlgorithm(string? algorithm) => algorithm switch
@@ -1312,35 +1281,38 @@ public sealed class SigstoreVerifier
     }
 
     /// <summary>
-    /// Verifies the artifact hash in a hashedrekord spec against the bundle's message digest.
-    /// Returns false only if both have hash values and they don't match.
+    /// Verifies the artifact hash in a hashedrekord v0.0.1 spec against the bundle's
+    /// message digest. The hash is the entry's only binding to the artifact, so anything
+    /// that prevents the comparison from being made is a verification failure rather than
+    /// a skipped check.
     /// </summary>
     internal static bool CrossVerifyHashedrekordArtifactHash(JsonElement spec, SigstoreBundle bundle)
     {
-        if (spec.TryGetProperty("data", out var dataElem) &&
-            dataElem.TryGetProperty("hash", out var hashElem))
+        if (!spec.TryGetProperty("data", out var dataElem) ||
+            !dataElem.TryGetProperty("hash", out var hashElem) ||
+            !hashElem.TryGetProperty("value", out var hashValue) ||
+            hashValue.GetString() is not { } expectedHash)
         {
-            if (hashElem.TryGetProperty("value", out var hashValue))
-            {
-                var expectedHash = hashValue.GetString();
-                if (expectedHash != null &&
-                    bundle.MessageSignature?.MessageDigest is { } digest)
-                {
-                    var hashAlg = hashElem.TryGetProperty("algorithm", out var algElem) ? algElem.GetString() : "sha256";
-
-                    // Only compare if the algorithms match
-                    if (MapRekorHashAlgorithm(hashAlg) == digest.Algorithm &&
-                        digest.Algorithm != HashAlgorithmType.Unspecified)
-                    {
-                        var bundleHashHex = Convert.ToHexString(digest.Digest.Span).ToLowerInvariant();
-                        if (!string.Equals(expectedHash, bundleHashHex, StringComparison.OrdinalIgnoreCase))
-                            return false;
-                    }
-                }
-            }
+            return false;
         }
 
-        return true;
+        // hashedrekord v0.0.1 records a message signature, so the bundle must carry the
+        // matching message digest for the entry to be bound to anything at all.
+        if (bundle.MessageSignature?.MessageDigest is not { } digest ||
+            digest.Algorithm == HashAlgorithmType.Unspecified)
+        {
+            return false;
+        }
+
+        var hashAlg = hashElem.TryGetProperty("algorithm", out var algElem) ? algElem.GetString() : null;
+
+        // A disagreement over the algorithm means the two digests are not comparable,
+        // which is exactly the case an attacker would want treated as "no mismatch".
+        if (MapRekorHashAlgorithm(hashAlg) != digest.Algorithm)
+            return false;
+
+        var bundleHashHex = Convert.ToHexString(digest.Digest.Span).ToLowerInvariant();
+        return string.Equals(expectedHash, bundleHashHex, StringComparison.OrdinalIgnoreCase);
     }
 
     private static HashAlgorithmType MapRekorHashAlgorithm(string? algorithm) => algorithm switch
@@ -1351,101 +1323,146 @@ public sealed class SigstoreVerifier
         _ => HashAlgorithmType.Unspecified
     };
 
-    private static bool CrossVerifyDsse(JsonElement spec, SigstoreBundle bundle, ReadOnlyMemory<byte> leafCertBytes)
+    /// <summary>
+    /// Reads a required base64-encoded string property, returning false when it is
+    /// absent, not a string, or not valid base64.
+    /// </summary>
+    private static bool TryGetBase64(JsonElement parent, string propertyName, out byte[] value)
+    {
+        value = [];
+        if (!parent.TryGetProperty(propertyName, out var elem) ||
+            elem.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        try
+        {
+            value = Convert.FromBase64String(elem.GetString()!);
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static byte[]? ComputeHash(HashAlgorithmType algorithm, ReadOnlySpan<byte> data) => algorithm switch
+    {
+        HashAlgorithmType.Sha256 => SHA256.HashData(data),
+        HashAlgorithmType.Sha384 => SHA384.HashData(data),
+        HashAlgorithmType.Sha512 => SHA512.HashData(data),
+        _ => null
+    };
+
+    /// <summary>
+    /// Cross-verifies a Rekor v1 DSSE envelope entry — either <c>intoto</c> v0.0.2
+    /// (<c>spec.content.{envelope, payloadHash}</c>) or <c>dsse</c> v0.0.1
+    /// (<c>spec.{signatures, payloadHash}</c>) — against the bundle's envelope.
+    /// </summary>
+    /// <remarks>
+    /// The two shapes name the same fields differently: intoto uses
+    /// <c>signatures[].sig</c>/<c>signatures[].publicKey</c> while dsse uses
+    /// <c>signatures[].signature</c>/<c>signatures[].verifier</c>. The caller supplies the
+    /// declared kind so each shape is held to its own field names, rather than trying both
+    /// and silently skipping the certificate binding when neither is found.
+    /// </remarks>
+    private static bool CrossVerifyDsse(string kind, JsonElement spec, SigstoreBundle bundle, ReadOnlyMemory<byte> leafCertBytes)
     {
         if (bundle.DsseEnvelope == null)
             return false;
 
-        // Handle the two Rekor v1 envelope shapes:
-        // 1. intoto v0.0.2: spec.content.{envelope, payloadHash}
-        // 2. dsse v0.0.1:   spec.{signatures, payloadHash}
-        // The Rekor v2 dsseV002 shape is dispatched by version in CrossVerifyTlogBody.
-
         JsonElement sigSource;
-        JsonElement? payloadHashElem = null;
+        JsonElement payloadHashElem;
+        string sigProperty;
+        string certProperty;
 
-        if (spec.TryGetProperty("content", out var content))
+        if (kind == "intoto")
         {
-            // intoto format: spec.content.{envelope, hash, payloadHash}
-            if (!content.TryGetProperty("envelope", out var envelope))
-                return true; // no envelope to cross-check
-            sigSource = envelope;
-            if (content.TryGetProperty("payloadHash", out var ph))
-                payloadHashElem = ph;
+            if (!spec.TryGetProperty("content", out var content) ||
+                !content.TryGetProperty("envelope", out sigSource))
+            {
+                return false;
+            }
+
+            if (!content.TryGetProperty("payloadHash", out payloadHashElem))
+                return false;
+
+            sigProperty = "sig";
+            certProperty = "publicKey";
         }
         else
         {
-            // dsse format: spec.{signatures, payloadHash, envelopeHash}
             sigSource = spec;
-            if (spec.TryGetProperty("payloadHash", out var ph))
-                payloadHashElem = ph;
+            if (!spec.TryGetProperty("payloadHash", out payloadHashElem))
+                return false;
+
+            sigProperty = "signature";
+            certProperty = "verifier";
         }
 
-        // Verify signature matches
-        if (sigSource.TryGetProperty("signatures", out var sigs) && sigs.GetArrayLength() > 0)
+        // The signature list is required by both schemas, and is what ties the entry to
+        // the envelope the bundle ships.
+        if (!sigSource.TryGetProperty("signatures", out var sigs) ||
+            sigs.ValueKind != JsonValueKind.Array ||
+            sigs.GetArrayLength() == 0)
         {
-            var firstSig = sigs[0];
-            if (firstSig.TryGetProperty("signature", out var sigContent) ||
-                firstSig.TryGetProperty("sig", out sigContent))
-            {
-                var sigStr = sigContent.GetString()!;
-                // The body may contain base64-of-base64 (intoto format stores
-                // the envelope JSON with base64 sigs, which then gets base64-encoded again).
-                // Try to decode and compare at the raw level.
-                byte[] expectedSig;
-                try
-                {
-                    expectedSig = Convert.FromBase64String(sigStr);
-                }
-                catch
-                {
-                    return false;
-                }
-
-                var bundleSig = bundle.DsseEnvelope.Signatures.Count > 0
-                    ? bundle.DsseEnvelope.Signatures[0].Sig
-                    : default(ReadOnlyMemory<byte>);
-
-                // Direct comparison first
-                if (!expectedSig.AsSpan().SequenceEqual(bundleSig.Span))
-                {
-                    // Try one more level of base64 decode (intoto v0.0.2 double-encodes)
-                    try
-                    {
-                        var innerStr = Encoding.UTF8.GetString(expectedSig);
-                        var innerSig = Convert.FromBase64String(innerStr);
-                        if (!innerSig.AsSpan().SequenceEqual(bundleSig.Span))
-                            return false;
-                    }
-                    catch
-                    {
-                        return false;
-                    }
-                }
-            }
-
-            // Verify certificate matches
-            if (firstSig.TryGetProperty("verifier", out var verifierContent))
-            {
-                var expectedCertPem = Encoding.UTF8.GetString(Convert.FromBase64String(verifierContent.GetString()!));
-                var expectedCertDer = ConvertPemToDer(expectedCertPem);
-                if (expectedCertDer != null && !expectedCertDer.AsSpan().SequenceEqual(leafCertBytes.Span))
-                    return false;
-            }
+            return false;
         }
 
-        // Verify payload hash matches
-        if (payloadHashElem is JsonElement hashEl &&
-            hashEl.TryGetProperty("value", out var hashValue))
+        var firstSig = sigs[0];
+        if (!TryGetBase64(firstSig, sigProperty, out var expectedSig))
+            return false;
+
+        var bundleSig = bundle.DsseEnvelope.Signatures.Count > 0
+            ? bundle.DsseEnvelope.Signatures[0].Sig
+            : default(ReadOnlyMemory<byte>);
+
+        if (!expectedSig.AsSpan().SequenceEqual(bundleSig.Span))
         {
-            var expectedHash = hashValue.GetString()!;
-            var payloadBytes = bundle.DsseEnvelope.Payload;
-            var computedHash = Convert.ToHexString(SHA256.HashData(payloadBytes.Span)).ToLowerInvariant();
-            if (computedHash != expectedHash)
+            // intoto v0.0.2 stores the envelope JSON — whose signatures are already
+            // base64 — and then base64-encodes the whole field again, so the raw
+            // signature is one decode further down.
+            byte[] innerSig;
+            try
+            {
+                innerSig = Convert.FromBase64String(Encoding.UTF8.GetString(expectedSig));
+            }
+            catch (Exception ex) when (ex is FormatException or ArgumentException or DecoderFallbackException)
+            {
+                return false;
+            }
+
+            if (!innerSig.AsSpan().SequenceEqual(bundleSig.Span))
                 return false;
         }
 
-        return true;
+        // Verify certificate matches
+        if (!TryGetBase64(firstSig, certProperty, out var certPemBytes))
+            return false;
+
+        var expectedCertDer = ConvertPemToDer(Encoding.UTF8.GetString(certPemBytes));
+        if (expectedCertDer == null || !expectedCertDer.AsSpan().SequenceEqual(leafCertBytes.Span))
+            return false;
+
+        // Verify payload hash matches
+        if (!payloadHashElem.TryGetProperty("value", out var hashValue) ||
+            hashValue.GetString() is not { } expectedHash)
+        {
+            return false;
+        }
+
+        var algorithm = MapRekorHashAlgorithm(
+            payloadHashElem.TryGetProperty("algorithm", out var algElem) ? algElem.GetString() : null);
+
+        var computed = ComputeHash(algorithm, bundle.DsseEnvelope.Payload.Span);
+        if (computed == null)
+            return false;
+
+        return string.Equals(
+            Convert.ToHexString(computed),
+            expectedHash,
+            StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool CrossVerifyDsseV002(JsonElement dsseV002, SigstoreBundle bundle, ReadOnlyMemory<byte> leafCertBytes)
@@ -1454,45 +1471,47 @@ public sealed class SigstoreVerifier
             return false;
 
         // Verify signature matches
-        if (dsseV002.TryGetProperty("signatures", out var sigs) && sigs.GetArrayLength() > 0)
+        if (!dsseV002.TryGetProperty("signatures", out var sigs) ||
+            sigs.ValueKind != JsonValueKind.Array ||
+            sigs.GetArrayLength() == 0)
         {
-            var firstSig = sigs[0];
-            if (firstSig.TryGetProperty("content", out var sigContent))
-            {
-                var expectedSig = Convert.FromBase64String(sigContent.GetString()!);
-                var bundleSig = bundle.DsseEnvelope.Signatures.Count > 0
-                    ? bundle.DsseEnvelope.Signatures[0].Sig
-                    : default(ReadOnlyMemory<byte>);
-                if (!expectedSig.AsSpan().SequenceEqual(bundleSig.Span))
-                    return false;
-            }
-
-            // Verify certificate matches
-            if (firstSig.TryGetProperty("verifier", out var verifier))
-            {
-                byte[]? expectedCertDer = null;
-                if (verifier.TryGetProperty("x509Certificate", out var x509) &&
-                    x509.TryGetProperty("rawBytes", out var rawBytes))
-                {
-                    expectedCertDer = Convert.FromBase64String(rawBytes.GetString()!);
-                }
-                if (expectedCertDer != null && !expectedCertDer.AsSpan().SequenceEqual(leafCertBytes.Span))
-                    return false;
-            }
+            return false;
         }
+
+        var firstSig = sigs[0];
+        if (!TryGetBase64(firstSig, "content", out var expectedSig))
+            return false;
+
+        var bundleSig = bundle.DsseEnvelope.Signatures.Count > 0
+            ? bundle.DsseEnvelope.Signatures[0].Sig
+            : default(ReadOnlyMemory<byte>);
+
+        if (!expectedSig.AsSpan().SequenceEqual(bundleSig.Span))
+            return false;
+
+        // Verify certificate matches
+        if (!firstSig.TryGetProperty("verifier", out var verifier) ||
+            !verifier.TryGetProperty("x509Certificate", out var x509) ||
+            !TryGetBase64(x509, "rawBytes", out var expectedCertDer))
+        {
+            return false;
+        }
+
+        if (!expectedCertDer.AsSpan().SequenceEqual(leafCertBytes.Span))
+            return false;
 
         // Verify payload hash matches
-        if (dsseV002.TryGetProperty("payloadHash", out var hashElem) &&
-            hashElem.TryGetProperty("digest", out var digest))
+        if (!dsseV002.TryGetProperty("payloadHash", out var hashElem) ||
+            !TryGetBase64(hashElem, "digest", out var expectedHash))
         {
-            var expectedHash = Convert.FromBase64String(digest.GetString()!);
-            var payloadBytes = bundle.DsseEnvelope.Payload;
-            var computedHash = SHA256.HashData(payloadBytes.Span);
-            if (!computedHash.AsSpan().SequenceEqual(expectedHash))
-                return false;
+            return false;
         }
 
-        return true;
+        var algorithm = MapRekorV2HashAlgorithm(
+            hashElem.TryGetProperty("algorithm", out var algElem) ? algElem.GetString() : "SHA2_256");
+
+        var computed = ComputeHash(algorithm, bundle.DsseEnvelope.Payload.Span);
+        return computed != null && computed.AsSpan().SequenceEqual(expectedHash);
     }
 
     private static byte[]? ConvertPemToDer(string pem)

--- a/src/Sigstore/Verification/SigstoreVerifier.cs
+++ b/src/Sigstore/Verification/SigstoreVerifier.cs
@@ -896,17 +896,7 @@ public sealed class SigstoreVerifier
 
     internal static bool VerifyEd25519Data(byte[] data, ReadOnlySpan<byte> signature, ReadOnlyMemory<byte> publicKeySpki)
     {
-        ReadOnlySpan<byte> rawKey;
-        if (publicKeySpki.Length == 44)
-            rawKey = publicKeySpki.Span.Slice(12);
-        else if (publicKeySpki.Length == 32)
-            rawKey = publicKeySpki.Span;
-        else
-            return false;
-
-        var algorithm = NSec.Cryptography.SignatureAlgorithm.Ed25519;
-        var pk = NSec.Cryptography.PublicKey.Import(algorithm, rawKey, NSec.Cryptography.KeyBlobFormat.RawPublicKey);
-        return algorithm.Verify(pk, data, signature);
+        return Ed25519SignatureVerifier.Verify(publicKeySpki.Span, data, signature);
     }
 
     private static (bool IsValid, string? Reason) VerifyHashWithKey(

--- a/src/Sigstore/Verification/SigstoreVerifier.cs
+++ b/src/Sigstore/Verification/SigstoreVerifier.cs
@@ -1091,6 +1091,14 @@ public sealed class SigstoreVerifier
 
     private static bool CrossVerifyHashedrekord(JsonElement spec, SigstoreBundle bundle, ReadOnlyMemory<byte> leafCertBytes)
     {
+        // Rekor v2 nests the entry under `hashedRekordV002` and uses a different
+        // shape to v1 (base64 digest rather than a hex `data.hash.value`, and a raw
+        // DER `verifier.x509Certificate` rather than a PEM `publicKey`).
+        if (spec.TryGetProperty("hashedRekordV002", out var v002))
+        {
+            return CrossVerifyHashedrekordV002(v002, bundle, leafCertBytes);
+        }
+
         // Verify signature matches
         if (spec.TryGetProperty("signature", out var sigElem))
         {
@@ -1121,6 +1129,134 @@ public sealed class SigstoreVerifier
             return false;
 
         return true;
+    }
+
+    /// <summary>
+    /// Cross-verifies a Rekor v2 <c>hashedrekord</c> (v0.0.2) entry against the bundle.
+    /// </summary>
+    /// <remarks>
+    /// Rekor v2 logs DSSE envelopes as hashedrekord entries rather than as dedicated
+    /// dsse entries (see sigstore/architecture-docs#63). The entry binds to the signed
+    /// content in two ways, both of which must hold:
+    /// <list type="bullet">
+    ///   <item><description><c>signature.content</c> equals the bundle's signature —
+    ///   the DSSE envelope signature, or the message signature.</description></item>
+    ///   <item><description><c>data.digest</c> equals the digest of the signed content —
+    ///   for a DSSE envelope that is the SHA-256 of its PAE, otherwise it is the
+    ///   artifact digest.</description></item>
+    /// </list>
+    /// Without these checks a bundle could carry a transparency log entry that attests
+    /// to different content than the envelope it ships with.
+    /// </remarks>
+    private static bool CrossVerifyHashedrekordV002(JsonElement v002, SigstoreBundle bundle, ReadOnlyMemory<byte> leafCertBytes)
+    {
+        if (v002.TryGetProperty("signature", out var sigElem))
+        {
+            if (sigElem.TryGetProperty("content", out var sigContent))
+            {
+                byte[] expectedSig;
+                try
+                {
+                    expectedSig = Convert.FromBase64String(sigContent.GetString()!);
+                }
+                catch
+                {
+                    return false;
+                }
+
+                var bundleSig = bundle.MessageSignature?.Signature
+                    ?? bundle.DsseEnvelope?.Signatures.FirstOrDefault()?.Sig
+                    ?? default(ReadOnlyMemory<byte>);
+
+                if (!expectedSig.AsSpan().SequenceEqual(bundleSig.Span))
+                    return false;
+            }
+
+            if (sigElem.TryGetProperty("verifier", out var verifier) &&
+                verifier.TryGetProperty("x509Certificate", out var x509) &&
+                x509.TryGetProperty("rawBytes", out var rawBytes))
+            {
+                byte[] expectedCertDer;
+                try
+                {
+                    expectedCertDer = Convert.FromBase64String(rawBytes.GetString()!);
+                }
+                catch
+                {
+                    return false;
+                }
+
+                if (!expectedCertDer.AsSpan().SequenceEqual(leafCertBytes.Span))
+                    return false;
+            }
+        }
+
+        if (!v002.TryGetProperty("data", out var dataElem) ||
+            !dataElem.TryGetProperty("digest", out var digestElem))
+        {
+            return true;
+        }
+
+        byte[] expectedDigest;
+        try
+        {
+            expectedDigest = Convert.FromBase64String(digestElem.GetString()!);
+        }
+        catch
+        {
+            return false;
+        }
+
+        var algorithm = dataElem.TryGetProperty("algorithm", out var algElem)
+            ? algElem.GetString()
+            : "SHA2_256";
+        var mapped = MapRekorV2HashAlgorithm(algorithm);
+
+        if (bundle.DsseEnvelope is { } envelope)
+        {
+            // Only SHA-256 PAE digests are defined for this entry type today; a
+            // different algorithm is not something we can cross-check.
+            if (mapped != HashAlgorithmType.Sha256)
+                return true;
+
+            var computed = SHA256.HashData(ComputeDssePae(envelope));
+            return computed.AsSpan().SequenceEqual(expectedDigest);
+        }
+
+        if (bundle.MessageSignature?.MessageDigest is { } messageDigest &&
+            messageDigest.Algorithm != HashAlgorithmType.Unspecified)
+        {
+            if (mapped != messageDigest.Algorithm)
+                return true;
+
+            return messageDigest.Digest.Span.SequenceEqual(expectedDigest);
+        }
+
+        return true;
+    }
+
+    private static HashAlgorithmType MapRekorV2HashAlgorithm(string? algorithm) => algorithm switch
+    {
+        "SHA2_256" => HashAlgorithmType.Sha256,
+        "SHA2_384" => HashAlgorithmType.Sha384,
+        "SHA2_512" => HashAlgorithmType.Sha512,
+        _ => HashAlgorithmType.Unspecified
+    };
+
+    /// <summary>
+    /// Computes the DSSE Pre-Authentication Encoding (PAE) for an envelope:
+    /// <c>"DSSEv1" SP LEN(type) SP type SP LEN(body) SP body</c>.
+    /// </summary>
+    internal static byte[] ComputeDssePae(DsseEnvelope envelope)
+    {
+        var payloadType = envelope.PayloadType;
+        var payload = envelope.Payload;
+        var prefix = Encoding.UTF8.GetBytes(
+            $"DSSEv1 {payloadType.Length} {payloadType} {payload.Length} ");
+        var pae = new byte[prefix.Length + payload.Length];
+        prefix.CopyTo(pae, 0);
+        payload.Span.CopyTo(pae.AsSpan(prefix.Length));
+        return pae;
     }
 
     /// <summary>
@@ -1583,13 +1719,7 @@ public sealed class SigstoreVerifier
 
         // Compute PAE (Pre-Authentication Encoding)
         // PAE = "DSSEv1" + SP + LEN(type) + SP + type + SP + LEN(body) + SP + body
-        var payloadType = envelope.PayloadType;
-        var payload = envelope.Payload;
-        var pae = Encoding.UTF8.GetBytes(
-            $"DSSEv1 {payloadType.Length} {payloadType} {payload.Length} ");
-        var paeBytes = new byte[pae.Length + payload.Length];
-        pae.CopyTo(paeBytes, 0);
-        payload.Span.CopyTo(paeBytes.AsSpan(pae.Length));
+        var paeBytes = ComputeDssePae(envelope);
 
         var sig = envelope.Signatures[0].Sig;
         return VerifySignatureWithCert(paeBytes, sig.Span, leafCert);

--- a/src/Sigstore/Verification/SigstoreVerifier.cs
+++ b/src/Sigstore/Verification/SigstoreVerifier.cs
@@ -1,4 +1,3 @@
-using System.Formats.Asn1;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -1034,23 +1033,13 @@ public sealed class SigstoreVerifier
         return true;
     }
 
-    // OID of the X.509 authority key identifier extension (RFC 5280 §4.2.1.1).
-    private const string AuthorityKeyIdentifierOid = "2.5.29.35";
-    // OID of the X.509 subject key identifier extension (RFC 5280 §4.2.1.2).
-    private const string SubjectKeyIdentifierOid = "2.5.29.14";
-
     /// <summary>
     /// Collects the certificates that may have issued <paramref name="leafCert"/>, most likely first.
     /// </summary>
     /// <remarks>
     /// A precertificate SCT commits to a hash of the issuing certificate's public key, so SCT
-    /// verification needs that exact certificate. Selecting it by subject name alone is not safe:
-    /// a certificate authority that rotates its key keeps its subject name, so a trusted root can
-    /// legitimately hold several distinct authorities sharing one name. Picking the first name match
-    /// then silently reconstructs the signed data with the wrong key and every SCT appears invalid.
-    /// Candidates whose subject key identifier matches the leaf's authority key identifier are
-    /// returned first, and the remaining name matches are retained as fallbacks so certificates that
-    /// omit those extensions still verify.
+    /// verification needs that exact certificate. See <see cref="IssuerCandidateIndex"/> for why the
+    /// issuer cannot be selected by subject name alone.
     /// </remarks>
     /// <param name="leafCert">The certificate whose issuer is being resolved.</param>
     /// <param name="intermediates">Intermediate certificates supplied by the bundle, if any.</param>
@@ -1066,91 +1055,7 @@ public sealed class SigstoreVerifier
         if (intermediates is { Count: > 0 })
             return [intermediates[0]];
 
-        var authorityKeyId = GetAuthorityKeyIdentifier(leafCert);
-
-        var preferred = new List<X509Certificate2>();
-        var fallback = new List<X509Certificate2>();
-
-        foreach (var ca in trustRoot.CertificateAuthorities)
-        {
-            foreach (var caCertBytes in ca.CertificateChain)
-            {
-                X509Certificate2 caCert;
-                try
-                {
-                    caCert = X509CertificateLoader.LoadCertificate(caCertBytes.Span);
-                }
-                catch
-                {
-                    continue;
-                }
-
-                if (!leafCert.IssuerName.RawData.AsSpan().SequenceEqual(caCert.SubjectName.RawData))
-                {
-                    caCert.Dispose();
-                    continue;
-                }
-
-                owned.Add(caCert);
-
-                var subjectKeyId = GetSubjectKeyIdentifier(caCert);
-
-                if (authorityKeyId is { } akid && subjectKeyId is { } skid && akid.Span.SequenceEqual(skid.Span))
-                    preferred.Add(caCert);
-                else
-                    fallback.Add(caCert);
-            }
-        }
-
-        preferred.AddRange(fallback);
-        return preferred;
-    }
-
-    private static ReadOnlyMemory<byte>? GetAuthorityKeyIdentifier(X509Certificate2 cert)
-    {
-        var extension = cert.Extensions[AuthorityKeyIdentifierOid];
-        if (extension == null)
-            return null;
-
-        try
-        {
-            // Unlike the subject key identifier extension, this type's byte[] constructor decodes
-            // the extension rather than treating the bytes as an identifier.
-            return new X509AuthorityKeyIdentifierExtension(extension.RawData, extension.Critical)
-                .KeyIdentifier;
-        }
-        catch (AsnContentException)
-        {
-            return null;
-        }
-        catch (CryptographicException)
-        {
-            return null;
-        }
-    }
-
-    private static ReadOnlyMemory<byte>? GetSubjectKeyIdentifier(X509Certificate2 cert)
-    {
-        var extension = cert.Extensions[SubjectKeyIdentifierOid];
-        if (extension == null)
-            return null;
-
-        try
-        {
-            // The extension value is a bare OCTET STRING (RFC 5280 §4.2.1.2). It is decoded here
-            // rather than through X509SubjectKeyIdentifierExtension, whose byte[] constructor would
-            // treat the encoded value as the identifier itself and leave its DER header in place,
-            // preventing it from ever matching an authority key identifier.
-            return new AsnReader(extension.RawData, AsnEncodingRules.DER).ReadOctetString();
-        }
-        catch (AsnContentException)
-        {
-            return null;
-        }
-        catch (CryptographicException)
-        {
-            return null;
-        }
+        return IssuerCandidateIndex.For(trustRoot).Resolve(leafCert, owned);
     }
 
 

--- a/src/Tuf/Tuf.csproj
+++ b/src/Tuf/Tuf.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSec.Cryptography" Version="25.4.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.7.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Tuf/Tuf.csproj
+++ b/src/Tuf/Tuf.csproj
@@ -14,6 +14,10 @@
     <RepositoryUrl>https://github.com/mitchdenny/sigstore-dotnet</RepositoryUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <!-- BEGIN: bot-managed baseline -->
+    <PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>
+    <!-- END: bot-managed baseline -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tuf/TufMetadataVerifier.cs
+++ b/src/Tuf/TufMetadataVerifier.cs
@@ -1,5 +1,8 @@
 using System.Security.Cryptography;
 using System.Text;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math.EC.Rfc8032;
+using Org.BouncyCastle.Security;
 using Tuf.Metadata;
 
 namespace Tuf;
@@ -106,11 +109,15 @@ public static class TufMetadataVerifier
         if (signature.Length != 64 || !TryDecodeEd25519PublicKey(publicKeyValue, out var publicKeyRaw))
             return false;
 
-        var algorithm = NSec.Cryptography.SignatureAlgorithm.Ed25519;
-        var publicKey = NSec.Cryptography.PublicKey.Import(algorithm, publicKeyRaw,
-            NSec.Cryptography.KeyBlobFormat.RawPublicKey);
-
-        return algorithm.Verify(publicKey, data, signature);
+        try
+        {
+            var publicKey = new Ed25519PublicKeyParameters(publicKeyRaw);
+            return publicKey.Verify(Ed25519.Algorithm.Ed25519, null, data, signature);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
     }
 
     private static bool VerifyRsaPss(byte[] data, byte[] signature, string pem, HashAlgorithmName hashAlgorithm)
@@ -162,16 +169,26 @@ public static class TufMetadataVerifier
         {
             var pemBytes = Encoding.ASCII.GetBytes(publicKeyValue);
             var derBytes = ExtractDerFromPem(pemBytes);
-            if (derBytes.Length != 44)
+            if (PublicKeyFactory.CreateKey(derBytes) is not Ed25519PublicKeyParameters publicKey)
             {
                 publicKeyRaw = [];
                 return false;
             }
 
-            publicKeyRaw = derBytes[^32..];
+            publicKeyRaw = publicKey.GetEncoded();
             return true;
         }
         catch (FormatException)
+        {
+            publicKeyRaw = [];
+            return false;
+        }
+        catch (IOException)
+        {
+            publicKeyRaw = [];
+            return false;
+        }
+        catch (ArgumentException)
         {
             publicKeyRaw = [];
             return false;

--- a/tests/Sigstore.AotCompatibility/Program.cs
+++ b/tests/Sigstore.AotCompatibility/Program.cs
@@ -1,0 +1,11 @@
+// Native AOT compatibility harness for the Sigstore and Tuf libraries.
+//
+// This project exists to be published with PublishAot=true. Both libraries are
+// listed as TrimmerRootAssembly items in the csproj, so ILC analyses every public
+// API they expose rather than only the members reached from this entry point. Any
+// trim or AOT warning (IL2xxx/IL3xxx) fails the build via TreatWarningsAsErrors.
+//
+// The body below is deliberately trivial: the rooting in the csproj, not the code
+// here, is what provides the coverage.
+
+Console.WriteLine("Sigstore and Tuf published successfully with native AOT.");

--- a/tests/Sigstore.AotCompatibility/Sigstore.AotCompatibility.csproj
+++ b/tests/Sigstore.AotCompatibility/Sigstore.AotCompatibility.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Sigstore.AotCompatibility</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>false</IsTestProject>
+    <PublishAot>true</PublishAot>
+    <!--
+      Report every trim/AOT warning individually instead of collapsing per-assembly
+      warnings into a single IL2104/IL3053. Combined with the repo-wide
+      TreatWarningsAsErrors, any regression fails the build.
+    -->
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sigstore\Sigstore.csproj" />
+    <ProjectReference Include="..\..\src\Tuf\Tuf.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      Root the whole of both libraries so ILC analyses their entire public surface,
+      not just the handful of members this harness happens to call. Without this the
+      trimmer would discard unreferenced APIs and never check them for AOT safety.
+    -->
+    <TrimmerRootAssembly Include="Sigstore" />
+    <TrimmerRootAssembly Include="Tuf" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Sigstore.Tests/Sigstore.Tests.csproj
+++ b/tests/Sigstore.Tests/Sigstore.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="NSec.Cryptography" Version="25.4.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
 

--- a/tests/Sigstore.Tests/Verification/Ed25519VerificationTests.cs
+++ b/tests/Sigstore.Tests/Verification/Ed25519VerificationTests.cs
@@ -1,4 +1,5 @@
-using NSec.Cryptography;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math.EC.Rfc8032;
 using Sigstore;
 
 namespace Sigstore.Tests.Verification;
@@ -8,11 +9,10 @@ public class Ed25519VerificationTests
     [Fact]
     public void VerifyEd25519Data_ValidSignature_WithRawKey()
     {
-        var algorithm = SignatureAlgorithm.Ed25519;
-        using var key = Key.Create(algorithm);
+        var key = CreateKey();
         var data = "hello ed25519"u8.ToArray();
-        var signature = algorithm.Sign(key, data);
-        var rawPublicKey = key.Export(KeyBlobFormat.RawPublicKey);
+        var signature = Sign(key, data);
+        var rawPublicKey = key.GeneratePublicKey().GetEncoded();
 
         var result = SigstoreVerifier.VerifyEd25519Data(data, signature, rawPublicKey);
 
@@ -22,13 +22,12 @@ public class Ed25519VerificationTests
     [Fact]
     public void VerifyEd25519Data_ValidSignature_WithSpkiKey()
     {
-        var algorithm = SignatureAlgorithm.Ed25519;
-        using var key = Key.Create(algorithm);
+        var key = CreateKey();
         var data = "hello ed25519 spki"u8.ToArray();
-        var signature = algorithm.Sign(key, data);
+        var signature = Sign(key, data);
 
         // Build a 44-byte SPKI: 12-byte prefix + 32-byte raw key
-        var rawKey = key.Export(KeyBlobFormat.RawPublicKey);
+        var rawKey = key.GeneratePublicKey().GetEncoded();
         // Ed25519 SPKI prefix (OID 1.3.101.112)
         byte[] spkiPrefix = [0x30, 0x2A, 0x30, 0x05, 0x06, 0x03, 0x2B, 0x65, 0x70, 0x03, 0x21, 0x00];
         var spki = new byte[44];
@@ -43,11 +42,10 @@ public class Ed25519VerificationTests
     [Fact]
     public void VerifyEd25519Data_InvalidSignature_ReturnsFalse()
     {
-        var algorithm = SignatureAlgorithm.Ed25519;
-        using var key = Key.Create(algorithm);
+        var key = CreateKey();
         var data = "hello ed25519"u8.ToArray();
-        var signature = algorithm.Sign(key, data);
-        var rawPublicKey = key.Export(KeyBlobFormat.RawPublicKey);
+        var signature = Sign(key, data);
+        var rawPublicKey = key.GeneratePublicKey().GetEncoded();
 
         // Corrupt the signature
         var badSig = signature.ToArray();
@@ -73,15 +71,56 @@ public class Ed25519VerificationTests
     [Fact]
     public void VerifyEd25519Data_WrongKey_ReturnsFalse()
     {
-        var algorithm = SignatureAlgorithm.Ed25519;
-        using var signingKey = Key.Create(algorithm);
-        using var wrongKey = Key.Create(algorithm);
+        var signingKey = CreateKey();
+        var wrongKey = CreateKey(1);
         var data = "hello ed25519"u8.ToArray();
-        var signature = algorithm.Sign(signingKey, data);
-        var wrongPublicKey = wrongKey.Export(KeyBlobFormat.RawPublicKey);
+        var signature = Sign(signingKey, data);
+        var wrongPublicKey = wrongKey.GeneratePublicKey().GetEncoded();
 
         var result = SigstoreVerifier.VerifyEd25519Data(data, signature, wrongPublicKey);
 
         Assert.False(result);
+    }
+
+    [Fact]
+    public void VerifyEd25519Data_Rfc8032TestVector_ReturnsTrue()
+    {
+        var publicKey = Convert.FromHexString(
+            "D75A980182B10AB7D54BFED3C964073A0EE172F3DAA62325AF021A68F707511A");
+        var signature = Convert.FromHexString(
+            "E5564300C360AC729086E2CC806E828A84877F1EB8E5D974D873E06522490155" +
+            "5FB8821590A33BACC61E39701CF9B46BD25BF5F0595BBE24655141438E7A100B");
+
+        var result = SigstoreVerifier.VerifyEd25519Data([], signature, publicKey);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void VerifyEd25519Data_InvalidSpkiPrefix_ReturnsFalse()
+    {
+        var key = CreateKey();
+        var data = "hello ed25519 spki"u8.ToArray();
+        var signature = Sign(key, data);
+        var invalidSpki = new byte[44];
+        key.GeneratePublicKey().GetEncoded().CopyTo(invalidSpki, 12);
+
+        var result = SigstoreVerifier.VerifyEd25519Data(data, signature, invalidSpki);
+
+        Assert.False(result);
+    }
+
+    private static Ed25519PrivateKeyParameters CreateKey(byte seedValue = 0)
+    {
+        var seed = new byte[Ed25519PrivateKeyParameters.KeySize];
+        seed.AsSpan().Fill(seedValue);
+        return new Ed25519PrivateKeyParameters(seed);
+    }
+
+    private static byte[] Sign(Ed25519PrivateKeyParameters key, ReadOnlySpan<byte> data)
+    {
+        var signature = new byte[Ed25519PrivateKeyParameters.SignatureSize];
+        key.Sign(Ed25519.Algorithm.Ed25519, null, data, signature);
+        return signature;
     }
 }

--- a/tests/Sigstore.Tests/Verification/SigstoreVerifierTests.cs
+++ b/tests/Sigstore.Tests/Verification/SigstoreVerifierTests.cs
@@ -1318,7 +1318,7 @@ public class SigstoreVerifierTests
     }
 
     [Fact]
-    public void ResolveIssuerCandidates_CasShareSubjectName_PrefersAuthorityKeyIdentifierMatch()
+    public void ResolveIssuerCandidates_CasShareSubjectName_SelectsAuthorityKeyIdentifierMatch()
     {
         using var oldCa = CreateTestCa(out var oldKey);
         using var newCa = CreateTestCa(out var newKey);
@@ -1335,8 +1335,43 @@ public class SigstoreVerifierTests
             {
                 var candidates = SigstoreVerifier.ResolveIssuerCandidates(leaf, null, trustedRoot, owned);
 
+                // The other authority publishes a different key, so it cannot have issued the leaf.
+                Assert.Single(candidates);
                 Assert.Equal(newCa.Thumbprint, candidates[0].Thumbprint);
+            }
+            finally
+            {
+                foreach (var candidate in owned)
+                    candidate.Dispose();
+            }
+        }
+    }
+
+    [Fact]
+    public void ResolveIssuerCandidates_CaWithoutSubjectKeyIdentifier_IsKeptAsFallback()
+    {
+        using var namedCa = CreateTestCa(out var namedKey);
+        using (namedKey)
+        using (var anonymousKey = ECDsa.Create(ECCurve.NamedCurves.nistP256))
+        {
+            // This authority shares the subject name but publishes no key identifier, so a mismatch
+            // with the leaf's authority key identifier cannot be established and it must be tried.
+            var request = new CertificateRequest(SharedCaSubject, anonymousKey, HashAlgorithmName.SHA256);
+            request.CertificateExtensions.Add(new X509BasicConstraintsExtension(true, false, 0, true));
+            using var anonymousCa = request.CreateSelfSigned(
+                DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+
+            using var leaf = CreateTestLeaf(namedCa, includeAuthorityKeyIdentifier: true);
+
+            var owned = new List<X509Certificate2>();
+            try
+            {
+                var candidates = SigstoreVerifier.ResolveIssuerCandidates(
+                    leaf, null, TrustedRootWith(anonymousCa, namedCa), owned);
+
                 Assert.Equal(2, candidates.Count);
+                Assert.Equal(namedCa.Thumbprint, candidates[0].Thumbprint);
+                Assert.Contains(candidates, c => c.Thumbprint == anonymousCa.Thumbprint);
             }
             finally
             {

--- a/tests/Sigstore.Tests/Verification/SigstoreVerifierTests.cs
+++ b/tests/Sigstore.Tests/Verification/SigstoreVerifierTests.cs
@@ -890,4 +890,155 @@ public class SigstoreVerifierTests
             };
         }
     }
+
+    // ---- Transparency log entry schema gating ----
+    //
+    // Cross-verification reads every field of an entry body by name. An entry whose
+    // schema is not recognised matches none of those names, so every check is skipped
+    // and the entry would otherwise be reported as verified without anything having
+    // been checked. These tests pin the fail-closed behaviour.
+
+    private static TransparencyLogEntry TlogEntryFor(string bodyJson, string? kind = null, string? kindVersion = null)
+        => new()
+        {
+            Body = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(bodyJson)),
+            Kind = kind,
+            KindVersion = kindVersion
+        };
+
+    private const string ValidHashHex = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+    private static string HashedrekordV001Body(string kind = "hashedrekord", string apiVersion = "0.0.1")
+        => $$"""
+        {
+            "kind": "{{kind}}",
+            "apiVersion": "{{apiVersion}}",
+            "spec": {
+                "signature": {},
+                "data": {"hash": {"algorithm": "sha256", "value": "{{ValidHashHex}}" } }
+            }
+        }
+        """;
+
+    [Fact]
+    public void CrossVerifyTlogBody_SupportedSchemaWithMatchingContents_ReturnsTrue()
+    {
+        // Positive control: the gate must let a schema we do support through.
+        var bundle = CreateBundleWithDigest(ValidHashHex, HashAlgorithmType.Sha256);
+
+        Assert.True(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(HashedrekordV001Body(), "hashedrekord", "0.0.1"),
+            bundle,
+            ReadOnlyMemory<byte>.Empty));
+    }
+
+    [Fact]
+    public void CrossVerifyTlogBody_UnknownKind_ReturnsFalse()
+    {
+        var bundle = CreateBundleWithDigest(ValidHashHex, HashAlgorithmType.Sha256);
+
+        Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(HashedrekordV001Body(kind: "rekord")),
+            bundle,
+            ReadOnlyMemory<byte>.Empty));
+    }
+
+    [Fact]
+    public void CrossVerifyTlogBody_UnsupportedApiVersionOfKnownKind_ReturnsFalse()
+    {
+        // The Rekor v2 regression in miniature: a kind we handle, carrying a schema
+        // version we do not. Every v0.0.1 field lookup would miss and pass silently.
+        var bundle = CreateBundleWithDigest(ValidHashHex, HashAlgorithmType.Sha256);
+
+        Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(HashedrekordV001Body(apiVersion: "0.0.3")),
+            bundle,
+            ReadOnlyMemory<byte>.Empty));
+    }
+
+    [Theory]
+    [InlineData("{\"apiVersion\": \"0.0.1\", \"spec\": {}}")]                        // no kind
+    [InlineData("{\"kind\": \"hashedrekord\", \"spec\": {}}")]                       // no apiVersion
+    [InlineData("{\"kind\": \"hashedrekord\", \"apiVersion\": \"0.0.1\"}")]          // no spec
+    [InlineData("{\"kind\": \"hashedrekord\", \"apiVersion\": \"0.0.1\", \"spec\": 1}")] // spec not an object
+    [InlineData("{\"kind\": 1, \"apiVersion\": \"0.0.1\", \"spec\": {}}")]           // kind not a string
+    public void CrossVerifyTlogBody_MalformedBody_ReturnsFalse(string bodyJson)
+    {
+        Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(bodyJson),
+            new SigstoreBundle(),
+            ReadOnlyMemory<byte>.Empty));
+    }
+
+    [Theory]
+    [InlineData("intoto", "0.0.1")]
+    [InlineData("hashedrekord", "0.0.2")]
+    public void CrossVerifyTlogBody_BundleKindVersionDisagreesWithBody_ReturnsFalse(string kind, string version)
+    {
+        // The bundle states the entry's kind/version out of band. If that disagrees with
+        // the signed body, the entry is not the one the bundle claims it is.
+        var bundle = CreateBundleWithDigest(ValidHashHex, HashAlgorithmType.Sha256);
+
+        Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(HashedrekordV001Body(), kind, version),
+            bundle,
+            ReadOnlyMemory<byte>.Empty));
+    }
+
+    [Fact]
+    public void CrossVerifyTlogBody_DeclaredVersionWithoutMatchingShape_ReturnsFalse()
+    {
+        // Declares v0.0.2 but carries the v0.0.1 shape. Dispatching by sniffing for a
+        // shape rather than by the declared version would route this to a handler that
+        // finds none of its fields and checks nothing.
+        var body = $$"""
+        {
+            "kind": "hashedrekord",
+            "apiVersion": "0.0.2",
+            "spec": {
+                "signature": {},
+                "data": {"hash": {"algorithm": "sha256", "value": "{{ValidHashHex}}" } }
+            }
+        }
+        """;
+        var bundle = CreateBundleWithDigest(ValidHashHex, HashAlgorithmType.Sha256);
+
+        Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(body, "hashedrekord", "0.0.2"),
+            bundle,
+            ReadOnlyMemory<byte>.Empty));
+    }
+
+    [Fact]
+    public void CrossVerifyTlogBody_HashedrekordV001WithoutSignature_ReturnsFalse()
+    {
+        // `signature` is required by the v0.0.1 schema and carries the bindings we check.
+        var body = $$"""
+        {
+            "kind": "hashedrekord",
+            "apiVersion": "0.0.1",
+            "spec": {"data": {"hash": {"algorithm": "sha256", "value": "{{ValidHashHex}}" } } }
+        }
+        """;
+        var bundle = CreateBundleWithDigest(ValidHashHex, HashAlgorithmType.Sha256);
+
+        Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(body, "hashedrekord", "0.0.1"),
+            bundle,
+            ReadOnlyMemory<byte>.Empty));
+    }
+
+    [Fact]
+    public void CrossVerifyTlogBody_ArtifactHashMismatchStillRejected_ReturnsFalse()
+    {
+        // Guards against the schema gate short-circuiting the content checks behind it.
+        var bundle = CreateBundleWithDigest(
+            "1111110123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+            HashAlgorithmType.Sha256);
+
+        Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(HashedrekordV001Body(), "hashedrekord", "0.0.1"),
+            bundle,
+            ReadOnlyMemory<byte>.Empty));
+    }
 }

--- a/tests/Sigstore.Tests/Verification/SigstoreVerifierTests.cs
+++ b/tests/Sigstore.Tests/Verification/SigstoreVerifierTests.cs
@@ -804,35 +804,61 @@ public class SigstoreVerifierTests
     }
 
     [Fact]
-    public void CrossVerifyHashedrekordArtifactHash_NoDigestInBundle_ReturnsTrue()
+    public void CrossVerifyHashedrekordArtifactHash_NoDigestInBundle_ReturnsFalse()
     {
         var hashHex = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
         var spec = CreateHashedrekordSpec(hashHex, "sha256");
-        // Bundle with no message digest — should skip check
+        // A hashedrekord entry records a message signature. With no message digest in the
+        // bundle there is nothing for the entry's hash to be bound to, so it must not pass.
         var bundle = new SigstoreBundle();
 
-        Assert.True(SigstoreVerifier.CrossVerifyHashedrekordArtifactHash(spec, bundle));
+        Assert.False(SigstoreVerifier.CrossVerifyHashedrekordArtifactHash(spec, bundle));
     }
 
     [Fact]
-    public void CrossVerifyHashedrekordArtifactHash_NoHashInSpec_ReturnsTrue()
+    public void CrossVerifyHashedrekordArtifactHash_NoHashInSpec_ReturnsFalse()
     {
+        // data.hash.value is required by the schema; without it the entry is not bound to
+        // any artifact and must not be treated as cross-verified.
         var json = """{"signature": {"content": ""}}""";
         var doc = JsonDocument.Parse(json);
-        var bundle = CreateBundleWithDigest("abcd", HashAlgorithmType.Sha256);
+        var bundle = CreateBundleWithDigest(ValidHashHex, HashAlgorithmType.Sha256);
 
-        Assert.True(SigstoreVerifier.CrossVerifyHashedrekordArtifactHash(doc.RootElement, bundle));
+        Assert.False(SigstoreVerifier.CrossVerifyHashedrekordArtifactHash(doc.RootElement, bundle));
     }
 
     [Fact]
-    public void CrossVerifyHashedrekordArtifactHash_DifferentAlgorithms_ReturnsTrue()
+    public void CrossVerifyHashedrekordArtifactHash_DifferentAlgorithms_ReturnsFalse()
     {
-        // Entry says sha512, bundle says sha256 — algorithms don't match, skip comparison
+        // Entry says sha512, bundle says sha256. The digests are not comparable, so the
+        // binding cannot be established — skipping the comparison would let a mismatched
+        // entry through by simply declaring a different algorithm.
         var hashHex = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
         var spec = CreateHashedrekordSpec(hashHex, "sha512");
         var bundle = CreateBundleWithDigest("0000000000000000000000000000000000000000000000000000000000000000", HashAlgorithmType.Sha256);
 
-        Assert.True(SigstoreVerifier.CrossVerifyHashedrekordArtifactHash(spec, bundle));
+        Assert.False(SigstoreVerifier.CrossVerifyHashedrekordArtifactHash(spec, bundle));
+    }
+
+    [Fact]
+    public void CrossVerifyHashedrekordArtifactHash_UnknownAlgorithm_ReturnsFalse()
+    {
+        var spec = CreateHashedrekordSpec(ValidHashHex, "md5");
+        var bundle = CreateBundleWithDigest(ValidHashHex, HashAlgorithmType.Sha256);
+
+        Assert.False(SigstoreVerifier.CrossVerifyHashedrekordArtifactHash(spec, bundle));
+    }
+
+    [Fact]
+    public void CrossVerifyHashedrekordArtifactHash_MissingAlgorithm_ReturnsFalse()
+    {
+        var json = $$"""
+        {"data": {"hash": {"value": "{{ValidHashHex}}"} } }
+        """;
+        var spec = JsonDocument.Parse(json).RootElement;
+        var bundle = CreateBundleWithDigest(ValidHashHex, HashAlgorithmType.Sha256);
+
+        Assert.False(SigstoreVerifier.CrossVerifyHashedrekordArtifactHash(spec, bundle));
     }
 
     private static JsonElement CreateHashedrekordSpec(string hashHex, string algorithm)
@@ -863,7 +889,7 @@ public class SigstoreVerifierTests
                     Algorithm = algorithm,
                     Digest = digestBytes
                 },
-                Signature = ReadOnlyMemory<byte>.Empty
+                Signature = FakeSignature
             }
         };
     }
@@ -908,13 +934,28 @@ public class SigstoreVerifierTests
 
     private const string ValidHashHex = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
 
+    private static readonly byte[] FakeSignature = [0x11, 0x22, 0x33, 0x44];
+    private static readonly byte[] FakeCertDer = [0x30, 0x82, 0x01, 0x02, 0xDE, 0xAD, 0xBE, 0xEF];
+
+    private static string FakeCertPemBase64 => Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(
+        $"-----BEGIN CERTIFICATE-----\n{Convert.ToBase64String(FakeCertDer)}\n-----END CERTIFICATE-----"));
+
+    /// <summary>
+    /// A complete, internally consistent hashedrekord v0.0.1 body matching the bundle
+    /// produced by <see cref="CreateBundleWithDigest"/> and <see cref="FakeCertDer"/>. It
+    /// is complete by default so that each negative test below fails for the reason it
+    /// names, rather than incidentally tripping over an unrelated missing field.
+    /// </summary>
     private static string HashedrekordV001Body(string kind = "hashedrekord", string apiVersion = "0.0.1")
         => $$"""
         {
             "kind": "{{kind}}",
             "apiVersion": "{{apiVersion}}",
             "spec": {
-                "signature": {},
+                "signature": {
+                    "content": "{{Convert.ToBase64String(FakeSignature)}}",
+                    "publicKey": {"content": "{{FakeCertPemBase64}}" }
+                },
                 "data": {"hash": {"algorithm": "sha256", "value": "{{ValidHashHex}}" } }
             }
         }
@@ -929,7 +970,41 @@ public class SigstoreVerifierTests
         Assert.True(SigstoreVerifier.CrossVerifyTlogBody(
             TlogEntryFor(HashedrekordV001Body(), "hashedrekord", "0.0.1"),
             bundle,
-            ReadOnlyMemory<byte>.Empty));
+            FakeCertDer));
+    }
+
+    [Fact]
+    public void CrossVerifyTlogBody_HashedrekordV001WithoutPublicKey_ReturnsFalse()
+    {
+        // The certificate binding is required: without it the entry is not tied to the
+        // identity the bundle was verified against.
+        var body = $$"""
+        {
+            "kind": "hashedrekord",
+            "apiVersion": "0.0.1",
+            "spec": {
+                "signature": {"content": "{{Convert.ToBase64String(FakeSignature)}}" },
+                "data": {"hash": {"algorithm": "sha256", "value": "{{ValidHashHex}}" } }
+            }
+        }
+        """;
+        var bundle = CreateBundleWithDigest(ValidHashHex, HashAlgorithmType.Sha256);
+
+        Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(body, "hashedrekord", "0.0.1"),
+            bundle,
+            FakeCertDer));
+    }
+
+    [Fact]
+    public void CrossVerifyTlogBody_HashedrekordV001WithDifferentCertificate_ReturnsFalse()
+    {
+        var bundle = CreateBundleWithDigest(ValidHashHex, HashAlgorithmType.Sha256);
+
+        Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(HashedrekordV001Body(), "hashedrekord", "0.0.1"),
+            bundle,
+            new byte[] { 0x30, 0x82, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00 }));
     }
 
     [Fact]
@@ -940,7 +1015,7 @@ public class SigstoreVerifierTests
         Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
             TlogEntryFor(HashedrekordV001Body(kind: "rekord")),
             bundle,
-            ReadOnlyMemory<byte>.Empty));
+            FakeCertDer));
     }
 
     [Fact]
@@ -953,7 +1028,7 @@ public class SigstoreVerifierTests
         Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
             TlogEntryFor(HashedrekordV001Body(apiVersion: "0.0.3")),
             bundle,
-            ReadOnlyMemory<byte>.Empty));
+            FakeCertDer));
     }
 
     [Theory]
@@ -982,7 +1057,7 @@ public class SigstoreVerifierTests
         Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
             TlogEntryFor(HashedrekordV001Body(), kind, version),
             bundle,
-            ReadOnlyMemory<byte>.Empty));
+            FakeCertDer));
     }
 
     [Fact]
@@ -1006,7 +1081,7 @@ public class SigstoreVerifierTests
         Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
             TlogEntryFor(body, "hashedrekord", "0.0.2"),
             bundle,
-            ReadOnlyMemory<byte>.Empty));
+            FakeCertDer));
     }
 
     [Fact]
@@ -1025,7 +1100,7 @@ public class SigstoreVerifierTests
         Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
             TlogEntryFor(body, "hashedrekord", "0.0.1"),
             bundle,
-            ReadOnlyMemory<byte>.Empty));
+            FakeCertDer));
     }
 
     [Fact]
@@ -1039,6 +1114,159 @@ public class SigstoreVerifierTests
         Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
             TlogEntryFor(HashedrekordV001Body(), "hashedrekord", "0.0.1"),
             bundle,
-            ReadOnlyMemory<byte>.Empty));
+            FakeCertDer));
+    }
+
+    // ---- DSSE envelope entry bindings ----
+    //
+    // intoto v0.0.2 names its signature fields `sig`/`publicKey` while dsse v0.0.1 uses
+    // `signature`/`verifier`. Looking only for the dsse names meant an intoto entry's
+    // certificate binding was never checked at all, so these tests pin both shapes.
+
+    private static readonly byte[] DssePayload = System.Text.Encoding.UTF8.GetBytes("""{"_type":"https://in-toto.io/Statement/v1"}""");
+
+    private static SigstoreBundle CreateDsseBundle() => new()
+    {
+        DsseEnvelope = new DsseEnvelope
+        {
+            PayloadType = "application/vnd.in-toto+json",
+            Payload = DssePayload,
+            Signatures = [new DsseSignature { Sig = FakeSignature }]
+        }
+    };
+
+    private static string DssePayloadHashHex =>
+        Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(DssePayload)).ToLowerInvariant();
+
+    private static string IntotoV002Body(string? certPemBase64 = null, string? payloadHashHex = null)
+        => $$"""
+        {
+            "kind": "intoto",
+            "apiVersion": "0.0.2",
+            "spec": {
+                "content": {
+                    "envelope": {
+                        "signatures": [{
+                            "sig": "{{Convert.ToBase64String(FakeSignature)}}",
+                            "publicKey": "{{certPemBase64 ?? FakeCertPemBase64}}"
+                        }]
+                    },
+                    "payloadHash": {"algorithm": "sha256", "value": "{{payloadHashHex ?? DssePayloadHashHex}}" }
+                }
+            }
+        }
+        """;
+
+    [Fact]
+    public void CrossVerifyTlogBody_IntotoV002WithMatchingContents_ReturnsTrue()
+    {
+        Assert.True(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(IntotoV002Body(), "intoto", "0.0.2"),
+            CreateDsseBundle(),
+            FakeCertDer));
+    }
+
+    [Fact]
+    public void CrossVerifyTlogBody_IntotoV002WithDifferentCertificate_ReturnsFalse()
+    {
+        // intoto stores the certificate under `publicKey`. Checking only `verifier` meant
+        // this entry — attesting to a different signer than the bundle — was accepted.
+        var otherCertPem = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(
+            $"-----BEGIN CERTIFICATE-----\n{Convert.ToBase64String(new byte[] { 0x30, 0x82, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00 })}\n-----END CERTIFICATE-----"));
+
+        Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(IntotoV002Body(certPemBase64: otherCertPem), "intoto", "0.0.2"),
+            CreateDsseBundle(),
+            FakeCertDer));
+    }
+
+    [Fact]
+    public void CrossVerifyTlogBody_IntotoV002WithMismatchedPayloadHash_ReturnsFalse()
+    {
+        Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(IntotoV002Body(payloadHashHex: ValidHashHex), "intoto", "0.0.2"),
+            CreateDsseBundle(),
+            FakeCertDer));
+    }
+
+    [Theory]
+    // no envelope to cross-check — previously accepted outright
+    [InlineData("""{"kind":"intoto","apiVersion":"0.0.2","spec":{"content":{}}}""")]
+    // envelope present but no signatures
+    [InlineData("""{"kind":"intoto","apiVersion":"0.0.2","spec":{"content":{"envelope":{"signatures":[]},"payloadHash":{"algorithm":"sha256","value":"x"}}}}""")]
+    // no payloadHash to bind the envelope contents
+    [InlineData("""{"kind":"intoto","apiVersion":"0.0.2","spec":{"content":{"envelope":{"signatures":[{"sig":"ESIzRA==","publicKey":"eA=="}]}}}}""")]
+    public void CrossVerifyTlogBody_IntotoV002WithMissingBindings_ReturnsFalse(string bodyJson)
+    {
+        Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(bodyJson, "intoto", "0.0.2"),
+            CreateDsseBundle(),
+            FakeCertDer));
+    }
+
+    [Fact]
+    public void CrossVerifyTlogBody_DsseV001WithMissingPayloadHash_ReturnsFalse()
+    {
+        var body = $$"""
+        {
+            "kind": "dsse",
+            "apiVersion": "0.0.1",
+            "spec": {
+                "signatures": [{
+                    "signature": "{{Convert.ToBase64String(FakeSignature)}}",
+                    "verifier": "{{FakeCertPemBase64}}"
+                }]
+            }
+        }
+        """;
+
+        Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(body, "dsse", "0.0.1"),
+            CreateDsseBundle(),
+            FakeCertDer));
+    }
+
+    [Fact]
+    public void CrossVerifyTlogBody_DsseV001WithMatchingContents_ReturnsTrue()
+    {
+        var body = $$"""
+        {
+            "kind": "dsse",
+            "apiVersion": "0.0.1",
+            "spec": {
+                "signatures": [{
+                    "signature": "{{Convert.ToBase64String(FakeSignature)}}",
+                    "verifier": "{{FakeCertPemBase64}}"
+                }],
+                "payloadHash": {"algorithm": "sha256", "value": "{{DssePayloadHashHex}}" }
+            }
+        }
+        """;
+
+        Assert.True(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(body, "dsse", "0.0.1"),
+            CreateDsseBundle(),
+            FakeCertDer));
+    }
+
+    [Theory]
+    // no data.digest to bind the signed content
+    [InlineData("""{"data":{"algorithm":"SHA2_256"},"signature":{"content":"ESIzRA==","verifier":{"x509Certificate":{"rawBytes":"MIIBAt6tvu8="}}}}""")]
+    // no data.algorithm, so the digest is not interpretable
+    [InlineData("""{"data":{"digest":"3q2+7w=="},"signature":{"content":"ESIzRA==","verifier":{"x509Certificate":{"rawBytes":"MIIBAt6tvu8="}}}}""")]
+    // no certificate binding
+    [InlineData("""{"data":{"algorithm":"SHA2_256","digest":"3q2+7w=="},"signature":{"content":"ESIzRA=="}}""")]
+    // no signature at all
+    [InlineData("""{"data":{"algorithm":"SHA2_256","digest":"3q2+7w=="}}""")]
+    public void CrossVerifyTlogBody_HashedrekordV002WithMissingBindings_ReturnsFalse(string v002Json)
+    {
+        var body = $$"""
+        {"kind":"hashedrekord","apiVersion":"0.0.2","spec":{"hashedRekordV002":{{v002Json}} } }
+        """;
+
+        Assert.False(SigstoreVerifier.CrossVerifyTlogBody(
+            TlogEntryFor(body, "hashedrekord", "0.0.2"),
+            CreateBundleWithDigest(ValidHashHex, HashAlgorithmType.Sha256),
+            FakeCertDer));
     }
 }

--- a/tests/Sigstore.Tests/Verification/SigstoreVerifierTests.cs
+++ b/tests/Sigstore.Tests/Verification/SigstoreVerifierTests.cs
@@ -1269,4 +1269,157 @@ public class SigstoreVerifierTests
             CreateBundleWithDigest(ValidHashHex, HashAlgorithmType.Sha256),
             FakeCertDer));
     }
+
+    // ---- Issuer resolution for SCT verification ----
+    //
+    // A precertificate SCT commits to a hash of the issuing certificate's public key, so the
+    // wrong issuer silently produces the wrong signed data and every SCT looks invalid. A CA
+    // that rotates its key keeps its subject name, so a trusted root can hold several distinct
+    // authorities sharing one name and the issuer cannot be chosen by name alone.
+
+    private const string SharedCaSubject = "CN=shared-ca, O=sigstore-test";
+
+    private static X509Certificate2 CreateTestCa(out ECDsa key)
+    {
+        key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var request = new CertificateRequest(SharedCaSubject, key, HashAlgorithmName.SHA256);
+        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(true, false, 0, true));
+        request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+        var now = DateTimeOffset.UtcNow;
+        return request.CreateSelfSigned(now.AddDays(-1), now.AddDays(1));
+    }
+
+    private static X509Certificate2 CreateTestLeaf(X509Certificate2 issuer, bool includeAuthorityKeyIdentifier)
+    {
+        using var leafKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var request = new CertificateRequest("CN=leaf, O=sigstore-test", leafKey, HashAlgorithmName.SHA256);
+        if (includeAuthorityKeyIdentifier)
+        {
+            request.CertificateExtensions.Add(
+                X509AuthorityKeyIdentifierExtension.CreateFromCertificate(issuer, true, false));
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        return request.Create(issuer, now.AddHours(-1), now.AddHours(1), [1, 2, 3, 4]);
+    }
+
+    private static TrustedRoot TrustedRootWith(params X509Certificate2[] cas)
+    {
+        return new TrustedRoot
+        {
+            CertificateAuthorities = cas
+                .Select(ca => new CertificateAuthorityInfo
+                {
+                    Uri = new Uri("https://fulcio.example"),
+                    CertificateChain = [ca.RawData]
+                })
+                .ToList()
+        };
+    }
+
+    [Fact]
+    public void ResolveIssuerCandidates_CasShareSubjectName_PrefersAuthorityKeyIdentifierMatch()
+    {
+        using var oldCa = CreateTestCa(out var oldKey);
+        using var newCa = CreateTestCa(out var newKey);
+        using (oldKey)
+        using (newKey)
+        using (var leaf = CreateTestLeaf(newCa, includeAuthorityKeyIdentifier: true))
+        {
+            // Both authorities share a subject name, and the one that did not issue the leaf is listed first.
+            Assert.Equal(oldCa.SubjectName.RawData, newCa.SubjectName.RawData);
+            var trustedRoot = TrustedRootWith(oldCa, newCa);
+
+            var owned = new List<X509Certificate2>();
+            try
+            {
+                var candidates = SigstoreVerifier.ResolveIssuerCandidates(leaf, null, trustedRoot, owned);
+
+                Assert.Equal(newCa.Thumbprint, candidates[0].Thumbprint);
+                Assert.Equal(2, candidates.Count);
+            }
+            finally
+            {
+                foreach (var candidate in owned)
+                    candidate.Dispose();
+            }
+        }
+    }
+
+    [Fact]
+    public void ResolveIssuerCandidates_LeafWithoutAuthorityKeyIdentifier_ReturnsEveryNameMatch()
+    {
+        using var oldCa = CreateTestCa(out var oldKey);
+        using var newCa = CreateTestCa(out var newKey);
+        using (oldKey)
+        using (newKey)
+        using (var leaf = CreateTestLeaf(newCa, includeAuthorityKeyIdentifier: false))
+        {
+            var trustedRoot = TrustedRootWith(oldCa, newCa);
+
+            var owned = new List<X509Certificate2>();
+            try
+            {
+                var candidates = SigstoreVerifier.ResolveIssuerCandidates(leaf, null, trustedRoot, owned);
+
+                // Nothing distinguishes the authorities, so the real issuer must still be tried.
+                Assert.Equal(2, candidates.Count);
+                Assert.Contains(candidates, c => c.Thumbprint == newCa.Thumbprint);
+            }
+            finally
+            {
+                foreach (var candidate in owned)
+                    candidate.Dispose();
+            }
+        }
+    }
+
+    [Fact]
+    public void ResolveIssuerCandidates_NonMatchingSubjectName_IsExcluded()
+    {
+        using var ca = CreateTestCa(out var caKey);
+        using (caKey)
+        using (var leaf = CreateTestLeaf(ca, includeAuthorityKeyIdentifier: true))
+        using (var unrelatedKey = ECDsa.Create(ECCurve.NamedCurves.nistP256))
+        {
+            var unrelatedRequest = new CertificateRequest("CN=unrelated-ca", unrelatedKey, HashAlgorithmName.SHA256);
+            unrelatedRequest.CertificateExtensions.Add(new X509BasicConstraintsExtension(true, false, 0, true));
+            using var unrelatedCa = unrelatedRequest.CreateSelfSigned(
+                DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+
+            var owned = new List<X509Certificate2>();
+            try
+            {
+                var candidates = SigstoreVerifier.ResolveIssuerCandidates(
+                    leaf, null, TrustedRootWith(unrelatedCa, ca), owned);
+
+                Assert.Single(candidates);
+                Assert.Equal(ca.Thumbprint, candidates[0].Thumbprint);
+            }
+            finally
+            {
+                foreach (var candidate in owned)
+                    candidate.Dispose();
+            }
+        }
+    }
+
+    [Fact]
+    public void ResolveIssuerCandidates_BundleSuppliesIntermediates_UsesThemVerbatim()
+    {
+        using var ca = CreateTestCa(out var caKey);
+        using (caKey)
+        using (var leaf = CreateTestLeaf(ca, includeAuthorityKeyIdentifier: true))
+        {
+            var intermediates = new X509Certificate2Collection(ca);
+
+            var owned = new List<X509Certificate2>();
+            var candidates = SigstoreVerifier.ResolveIssuerCandidates(
+                leaf, intermediates, TrustedRootWith(), owned);
+
+            Assert.Single(candidates);
+            Assert.Equal(ca.Thumbprint, candidates[0].Thumbprint);
+            Assert.Empty(owned);
+        }
+    }
 }

--- a/tests/Tuf.Tests/Tuf.Tests.csproj
+++ b/tests/Tuf.Tests/Tuf.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="xunit" Version="2.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />

--- a/tests/Tuf.Tests/TufSignatureVerificationTests.cs
+++ b/tests/Tuf.Tests/TufSignatureVerificationTests.cs
@@ -326,4 +326,59 @@ public class TufSignatureVerificationTests
 
         Assert.True(result, "Ed25519 SPKI PEM public keys should verify successfully.");
     }
+
+    [Theory]
+    // Well-formed SPKI carrying an unrecognised algorithm OID (1.2.3.4).
+    [InlineData("MCwwBwYDKgMEBQADIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==")]
+    // Structurally invalid DER.
+    [InlineData("AQIDBA==")]
+    // Ed25519 OID with a key that is not 32 bytes.
+    [InlineData("MBIwBQYDK2VwAwkAAAAAAAAAAAA=")]
+    public void VerifyThreshold_Ed25519MalformedPemPublicKey_ReturnsFalse(string base64Der)
+    {
+        var pem = $"-----BEGIN PUBLIC KEY-----\n{base64Der}\n-----END PUBLIC KEY-----";
+
+        var result = VerifyWithEd25519PemKey(pem);
+
+        Assert.False(result, "Malformed Ed25519 public keys must fail verification without throwing.");
+    }
+
+    [Fact]
+    public void VerifyThreshold_Ed25519KeyTypeWithRsaPemPublicKey_ReturnsFalse()
+    {
+        using var rsa = System.Security.Cryptography.RSA.Create(2048);
+        var pem = $"-----BEGIN PUBLIC KEY-----\n{Convert.ToBase64String(rsa.ExportSubjectPublicKeyInfo())}\n-----END PUBLIC KEY-----";
+
+        var result = VerifyWithEd25519PemKey(pem);
+
+        Assert.False(result, "A non-Ed25519 key must not satisfy an ed25519 key entry.");
+    }
+
+    private static bool VerifyWithEd25519PemKey(string pem)
+    {
+        var role = new Tuf.Metadata.TufRole
+        {
+            KeyIds = ["ed25519-key"],
+            Threshold = 1
+        };
+        var keys = new Dictionary<string, Tuf.Metadata.TufKey>
+        {
+            ["ed25519-key"] = new()
+            {
+                KeyType = "ed25519",
+                Scheme = "ed25519",
+                KeyVal = new Dictionary<string, string> { ["public"] = pem }
+            }
+        };
+        var signatures = new List<Tuf.Metadata.TufSignature>
+        {
+            new()
+            {
+                KeyId = "ed25519-key",
+                Sig = new string('0', 128)
+            }
+        };
+
+        return TufMetadataVerifier.VerifyThreshold(signatures, [], role, keys);
+    }
 }

--- a/tests/Tuf.Tests/TufSignatureVerificationTests.cs
+++ b/tests/Tuf.Tests/TufSignatureVerificationTests.cs
@@ -1,4 +1,5 @@
-using NSec.Cryptography;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math.EC.Rfc8032;
 using Tuf.Serialization;
 
 namespace Tuf.Tests;
@@ -245,11 +246,11 @@ public class TufSignatureVerificationTests
     [Fact]
     public void VerifyThreshold_Ed25519RawHexPublicKey_ThresholdMet()
     {
-        var algorithm = SignatureAlgorithm.Ed25519;
-        using var signingKey = Key.Create(algorithm);
+        var signingKey = new Ed25519PrivateKeyParameters(new byte[Ed25519PrivateKeyParameters.KeySize]);
         var data = "hello tuf ed25519"u8.ToArray();
-        var signature = algorithm.Sign(signingKey, data);
-        var rawPublicKey = signingKey.Export(KeyBlobFormat.RawPublicKey);
+        var signature = new byte[Ed25519PrivateKeyParameters.SignatureSize];
+        signingKey.Sign(Ed25519.Algorithm.Ed25519, null, data, signature);
+        var rawPublicKey = signingKey.GeneratePublicKey().GetEncoded();
 
         var role = new Tuf.Metadata.TufRole
         {
@@ -282,5 +283,47 @@ public class TufSignatureVerificationTests
         var result = TufMetadataVerifier.VerifyThreshold(signatures, data, role, keys);
 
         Assert.True(result, "Ed25519 raw-hex public keys should verify successfully.");
+    }
+
+    [Fact]
+    public void VerifyThreshold_Ed25519PemPublicKey_Rfc8032Vector_ThresholdMet()
+    {
+        var publicKey = Convert.FromHexString(
+            "D75A980182B10AB7D54BFED3C964073A0EE172F3DAA62325AF021A68F707511A");
+        var signature = Convert.FromHexString(
+            "E5564300C360AC729086E2CC806E828A84877F1EB8E5D974D873E06522490155" +
+            "5FB8821590A33BACC61E39701CF9B46BD25BF5F0595BBE24655141438E7A100B");
+        byte[] spkiPrefix = [0x30, 0x2A, 0x30, 0x05, 0x06, 0x03, 0x2B, 0x65, 0x70, 0x03, 0x21, 0x00];
+        var spki = new byte[spkiPrefix.Length + publicKey.Length];
+        spkiPrefix.CopyTo(spki, 0);
+        publicKey.CopyTo(spki, spkiPrefix.Length);
+        var pem = $"-----BEGIN PUBLIC KEY-----\n{Convert.ToBase64String(spki)}\n-----END PUBLIC KEY-----";
+
+        var role = new Tuf.Metadata.TufRole
+        {
+            KeyIds = ["ed25519-key"],
+            Threshold = 1
+        };
+        var keys = new Dictionary<string, Tuf.Metadata.TufKey>
+        {
+            ["ed25519-key"] = new()
+            {
+                KeyType = "ed25519",
+                Scheme = "ed25519",
+                KeyVal = new Dictionary<string, string> { ["public"] = pem }
+            }
+        };
+        var signatures = new List<Tuf.Metadata.TufSignature>
+        {
+            new()
+            {
+                KeyId = "ed25519-key",
+                Sig = Convert.ToHexString(signature).ToLowerInvariant()
+            }
+        };
+
+        var result = TufMetadataVerifier.VerifyThreshold(signatures, [], role, keys);
+
+        Assert.True(result, "Ed25519 SPKI PEM public keys should verify successfully.");
     }
 }


### PR DESCRIPTION
## Summary

Replaces NSec with BouncyCastle for Ed25519, modernizes the build and release pipeline, and — during that work — fixes several verification bugs found along the way, including one latent vulnerability.

### Ed25519 via BouncyCastle

- Replaces `NSec.Cryptography` and its native libsodium dependency with managed `BouncyCastle.Cryptography` 2.7.0.
- Centralizes Ed25519 verification, validates SPKI encodings, and covers raw/SPKI/PEM behavior with RFC 8032 vectors.

BouncyCastle removes the platform-specific native runtime asset, which is what allows the libraries to publish under Native AOT. The tradeoff is download size: BouncyCastle 2.7.0 is about 8.7 MB against roughly 4.4 MB combined for NSec 25.4.0 plus libsodium 1.0.20.1.

### Verification fixes

These were found while validating the migration, and are the most important part of the change:

- **Transparency log entry bindings were being skipped rather than enforced.** `intoto` v0.0.2 names its signature fields `sig`/`publicKey`, while `dsse` v0.0.1 uses `signature`/`verifier`. Only the `dsse` names were looked up, so an `intoto` entry's certificate binding was never actually checked. All five cross-verification paths are now rewritten to require their bindings.
- **Unsupported log entry schemas passed silently.** Verification now gates on an explicit `(kind, apiVersion)` allow-list, dispatches by version, and checks that the entry body's `kindVersion` agrees with the bundle's.
- **SCT issuer resolution matched on subject DN.** Sigstore staging now runs two CAs sharing `/O=sigstore.dev/CN=sigstore-intermediate` with different keys, so picking the first name match hashed the wrong key and failed verification depending on which CA issued the certificate. The issuer is now resolved by key identifier (AKI/SKI).
- Adapts to sigstore-conformance infrastructure changes (OIDC beacon deprecation, token moved to GCS), bumps the suite to v0.0.29, and implements `hashedrekord` v0.0.2 cross-verification.

### Performance

Issuer resolution rescanned every certificate authority on each verification. It is now backed by a per-trusted-root index cached with a `ConditionalWeakTable`, which also tightens correctness: a CA publishing a different SKI cannot have issued the leaf and is excluded rather than retained as a fallback.

Measured worst case (leaf issued by the last CA), per resolve:

| Same-subject CAs | Before | After |
|---|---|---|
| 2 | 0.057 ms | 0.039 ms |
| 100 | 3.0 ms | 0.056 ms |
| 1000 | 27.2 ms | 0.021 ms |

### Build and release

- Branch-derived versioning: `main` publishes alphas, `release/X.Y` publishes betas for that line's next patch, and a manual dispatch on `release/X.Y` publishes the stable version, tag, and GitHub Release.
- One version is computed per run and fanned out, so a tag appearing mid-run cannot desynchronize jobs.
- Verifies produced NuGet contents rather than assuming a successful pack, guards fork previews and stale betas, and makes publish and release-creation retries idempotent.
- Removes the mutable `vX.Y.0-dev` marker-tag step.
- Adds macOS to the build matrix, and a Native AOT job that roots both libraries so trim/AOT regressions fail the build.

### API compatibility

Package validation now runs during pack against the last stable release (0.5.0), so removing or changing public API fails the build. The baseline sits in a bot-managed block in both project files, and a workflow raises a pull request moving it forward after each stable release.

The assembly version is now derived from the package version as `Major.Minor.Patch.0`, keeping all version attributes consistent, with build detail confined to `FileVersion`/`InformationalVersion`. This surfaced a regression introduced here: every published package (0.2.0–0.5.0) shipped assembly version `1.0.0.0`, because the previous build never flowed the package version into the assembly. A `0.6.0` package would therefore have moved the assembly version *backwards* for existing consumers. Since a package version below `1.0.0` cannot satisfy that, the `0.x` series is closed and the version calculator floors new lines off `main` at `1.0`.

## Compatibility

**The public API is unchanged.** Comparing the public and protected surface of the shipped 0.5.0 assemblies against this branch produces zero differences across both packages (52 types in Sigstore, 23 in Tuf).

Two things are still visible to consumers:

- **Dependency swap.** Both packages replace `NSec.Cryptography` 25.4.0 with `BouncyCastle.Cryptography` 2.7.0.
- **Verification is stricter.** The fixes above are behavioral breaks even though no signature changed: unsupported log entry schemas and entries with unverifiable bindings now fail instead of passing. This is intended, but it can turn a previously "successful" verification into a failure, so it should not be treated as a drop-in upgrade.

## Validation

- 347 Sigstore tests and 55 TUF tests pass.
- Conformance suites pass against production and staging, plus TUF conformance.
- Native AOT publish succeeds for both conformance executables; the guard was confirmed to fail when a reflection probe is injected.
- Version calculator matrix, including the 1.x floor, release-branch servicing, and malformed-branch cases.
- Baseline resolve/rewrite scripts unit tested; the PR-raising path was exercised end to end against a local remote.
- Package validation confirmed to fail on an injected public-member removal (`CP0002`) and on a lowered assembly version (`CP0003`).
- Both packages carry the same computed version, include BouncyCastle 2.7.0, and no longer reference NSec or libsodium.