### PR TITLE
Pin package validation baseline to 1.0.0 on release/1.0

### DIFF
--- a/src/Sigstore/Sigstore.csproj
+++ b/src/Sigstore/Sigstore.csproj
@@ -16,7 +16,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <EnablePackageValidation>true</EnablePackageValidation>
     <!-- BEGIN: bot-managed baseline -->
-    <PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
     <!-- END: bot-managed baseline -->
   </PropertyGroup>
 

--- a/src/Tuf/Tuf.csproj
+++ b/src/Tuf/Tuf.csproj
@@ -16,7 +16,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <EnablePackageValidation>true</EnablePackageValidation>
     <!-- BEGIN: bot-managed baseline -->
-    <PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
     <!-- END: bot-managed baseline -->
   </PropertyGroup>
 


### PR DESCRIPTION
Pins `<PackageValidationBaselineVersion>` in `src/Sigstore/Sigstore.csproj` and
`src/Tuf/Tuf.csproj` to **1.0.0**, following the stable release on `release/1.0`.

- Previous baseline: `0.5.0`
- New baseline: `1.0.0`

Once merged, every build on `release/1.0` compares the public API against the 1.0.0 packages
on NuGet.org and fails on an undeclared breaking change. See
`.github/workflows/baseline-bump.yml` for when this pull request is raised.