### PR TITLE
Avoid publishing after baseline-only merges on release/1.0

### DIFF
--- a/.github/actions/baseline-bump/bump.sh
+++ b/.github/actions/baseline-bump/bump.sh
@@ -1,8 +1,8 @@
 set -euo pipefail
 
 # Opens (or updates) a pull request that bumps the package validation baseline on BRANCH to
-# VERSION. Idempotent: if the projects on BRANCH already pin VERSION the script exits without
-# touching git or the pull request.
+# VERSION. Idempotent: if BRANCH already pins VERSION the script exits without touching git
+# or the pull request.
 #
 # Inputs:
 #   $1 BRANCH  - the base branch to target (e.g. main, release/0.5)
@@ -14,7 +14,7 @@ BRANCH="${1:?branch required}"
 VERSION="${2:?version required}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECTS=(src/Sigstore/Sigstore.csproj src/Tuf/Tuf.csproj)
+BASELINE_FILE=PackageValidationBaseline.props
 
 if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
   echo "::notice::Branch '$BRANCH' does not exist on origin; skipping."
@@ -33,17 +33,15 @@ git worktree add --detach "$WORKTREE" "origin/$BRANCH" >/dev/null
 
 pushd "$WORKTREE" >/dev/null
 
-for project in "${PROJECTS[@]}"; do
-  if [[ ! -f "$project" ]]; then
-    echo "::notice::$project is not present on $BRANCH; skipping."
-    popd >/dev/null
-    exit 0
-  fi
-done
+if [[ ! -f "$BASELINE_FILE" ]]; then
+  echo "::notice::$BASELINE_FILE is not present on $BRANCH; skipping."
+  popd >/dev/null
+  exit 0
+fi
 
-PREVIOUS="$(VERSION="$VERSION" bash "$SCRIPT_DIR/rewrite.sh" "${PROJECTS[@]}")"
+PREVIOUS="$(VERSION="$VERSION" bash "$SCRIPT_DIR/rewrite.sh" "$BASELINE_FILE")"
 
-if git diff --quiet -- "${PROJECTS[@]}"; then
+if git diff --quiet -- "$BASELINE_FILE"; then
   echo "Baseline on $BRANCH is already $VERSION; nothing to do."
   popd >/dev/null
   exit 0
@@ -68,14 +66,14 @@ else
 fi
 
 git checkout -B "$HEAD_BRANCH" --quiet
-git add "${PROJECTS[@]}"
+git add "$BASELINE_FILE"
 git commit --quiet -m "ci: pin package validation baseline to $VERSION on $BRANCH"
 git push --force-with-lease --quiet origin "$HEAD_BRANCH"
 
 TITLE="Pin package validation baseline to $VERSION on $BRANCH"
 BODY="$(cat <<EOF
-Pins \`<PackageValidationBaselineVersion>\` in \`src/Sigstore/Sigstore.csproj\` and
-\`src/Tuf/Tuf.csproj\` to **$VERSION**, following the stable release on \`$BRANCH\`.
+Pins \`<PackageValidationBaselineVersion>\` in \`PackageValidationBaseline.props\` to
+**$VERSION**, following the stable release on \`$BRANCH\`.
 
 - Previous baseline: \`${PREVIOUS:-none}\`
 - New baseline: \`$VERSION\`

--- a/.github/actions/baseline-bump/rewrite.sh
+++ b/.github/actions/baseline-bump/rewrite.sh
@@ -1,7 +1,7 @@
 set -euo pipefail
 
-# Rewrites the bot-managed <PackageValidationBaselineVersion> block in each project file
-# passed as an argument, and prints the previous baseline of the first file that had one.
+# Rewrites the bot-managed <PackageValidationBaselineVersion> block in each file passed as an
+# argument, and prints the previous baseline of the first file that had one.
 #
 # Only the lines between the markers are touched, so hand-written package metadata around
 # the block is preserved. Rewriting is idempotent: running it twice with the same version
@@ -15,7 +15,7 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 fi
 
 if [[ $# -eq 0 ]]; then
-  echo "::error::At least one project file is required." >&2
+  echo "::error::At least one baseline file is required." >&2
   exit 1
 fi
 
@@ -24,18 +24,18 @@ END_MARKER="<!-- END: bot-managed baseline -->"
 
 PREVIOUS=""
 
-for project in "$@"; do
-  if [[ ! -f "$project" ]]; then
-    echo "::error::$project does not exist." >&2
+for file in "$@"; do
+  if [[ ! -f "$file" ]]; then
+    echo "::error::$file does not exist." >&2
     exit 1
   fi
 
-  if ! grep -qF "$BEGIN_MARKER" "$project" || ! grep -qF "$END_MARKER" "$project"; then
-    echo "::error::bot-managed baseline block not found in $project." >&2
+  if ! grep -qF "$BEGIN_MARKER" "$file" || ! grep -qF "$END_MARKER" "$file"; then
+    echo "::error::bot-managed baseline block not found in $file." >&2
     exit 1
   fi
 
-  current="$(sed -n "/$(printf '%s' "$BEGIN_MARKER" | sed 's@[]\/$*.^[]@\\&@g')/,/$(printf '%s' "$END_MARKER" | sed 's@[]\/$*.^[]@\\&@g')/p" "$project" \
+  current="$(sed -n "/$(printf '%s' "$BEGIN_MARKER" | sed 's@[]\/$*.^[]@\\&@g')/,/$(printf '%s' "$END_MARKER" | sed 's@[]\/$*.^[]@\\&@g')/p" "$file" \
     | grep -oE '<PackageValidationBaselineVersion>[^<]+</PackageValidationBaselineVersion>' \
     | head -n1 \
     | sed -E 's@</?PackageValidationBaselineVersion>@@g' || true)"
@@ -61,9 +61,9 @@ for project in "$@"; do
     }
     inside { next }
     { print }
-  ' "$project" > "$rewritten"
+  ' "$file" > "$rewritten"
 
-  mv "$rewritten" "$project"
+  mv "$rewritten" "$file"
 done
 
 echo "$PREVIOUS"

--- a/.github/actions/baseline-bump/test.sh
+++ b/.github/actions/baseline-bump/test.sh
@@ -1,7 +1,7 @@
 set -euo pipefail
 
 # Exercises resolve.sh against synthetic tag histories and rewrite.sh against synthetic
-# project files. bump.sh is not covered here because it talks to GitHub.
+# baseline files. bump.sh is not covered here because it talks to GitHub.
 
 ACTION_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEST_ROOT="$(mktemp -d)"
@@ -99,50 +99,47 @@ resolve_case "a patch on the newest line bumps main" release v1.0.1 "" \
 # rewrite.sh
 # ---------------------------------------------------------------------------
 
-make_project() {
+make_baseline_file() {
   cat > "$1" <<'EOF'
-<Project Sdk="Microsoft.NET.Sdk">
-
+<Project>
   <PropertyGroup>
-    <PackageId>Example</PackageId>
-    <EnablePackageValidation>true</EnablePackageValidation>
+    <ExampleBefore>true</ExampleBefore>
     <!-- BEGIN: bot-managed baseline -->
     <PackageValidationBaselineVersion>0.4.0</PackageValidationBaselineVersion>
     <!-- END: bot-managed baseline -->
-    <Description>Example</Description>
+    <ExampleAfter>true</ExampleAfter>
   </PropertyGroup>
-
 </Project>
 EOF
 }
 
-PROJECT_A="$TEST_ROOT/A.csproj"
-PROJECT_B="$TEST_ROOT/B.csproj"
-make_project "$PROJECT_A"
-make_project "$PROJECT_B"
+BASELINE_A="$TEST_ROOT/A.props"
+BASELINE_B="$TEST_ROOT/B.props"
+make_baseline_file "$BASELINE_A"
+make_baseline_file "$BASELINE_B"
 
-PREVIOUS="$(VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh" "$PROJECT_A" "$PROJECT_B")"
+PREVIOUS="$(VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh" "$BASELINE_A" "$BASELINE_B")"
 [[ "$PREVIOUS" == "0.4.0" ]] || fail "rewrite reports the previous baseline (got '$PREVIOUS')"
 
-grep -q '<PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>' "$PROJECT_A" \
+grep -q '<PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>' "$BASELINE_A" \
   || fail "rewrite pins the new version"
-grep -q '<PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>' "$PROJECT_B" \
-  || fail "rewrite pins every project passed to it"
-grep -q '<Description>Example</Description>' "$PROJECT_A" \
+grep -q '<PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>' "$BASELINE_B" \
+  || fail "rewrite pins every file passed to it"
+grep -q '<ExampleAfter>true</ExampleAfter>' "$BASELINE_A" \
   || fail "rewrite preserves content after the block"
-grep -q '<EnablePackageValidation>true</EnablePackageValidation>' "$PROJECT_A" \
+grep -q '<ExampleBefore>true</ExampleBefore>' "$BASELINE_A" \
   || fail "rewrite preserves content before the block"
-grep -q '^    <PackageValidationBaselineVersion>' "$PROJECT_A" \
+grep -q '^    <PackageValidationBaselineVersion>' "$BASELINE_A" \
   || fail "rewrite preserves the indentation of the block"
-[[ "$(grep -c '<PackageValidationBaselineVersion>' "$PROJECT_A")" == "1" ]] \
+[[ "$(grep -c '<PackageValidationBaselineVersion>' "$BASELINE_A")" == "1" ]] \
   || fail "rewrite leaves exactly one baseline element"
 
-cp "$PROJECT_A" "$TEST_ROOT/A.before"
-VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh" "$PROJECT_A" >/dev/null
-cmp -s "$PROJECT_A" "$TEST_ROOT/A.before" || fail "rewrite is idempotent"
+cp "$BASELINE_A" "$TEST_ROOT/A.before"
+VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh" "$BASELINE_A" >/dev/null
+cmp -s "$BASELINE_A" "$TEST_ROOT/A.before" || fail "rewrite is idempotent"
 
-# A block that lost its element still gets one back, so a hand-edited project recovers.
-cat > "$TEST_ROOT/empty.csproj" <<'EOF'
+# A block that lost its element still gets one back, so a hand-edited file recovers.
+cat > "$TEST_ROOT/empty.props" <<'EOF'
 <Project>
   <PropertyGroup>
     <!-- BEGIN: bot-managed baseline -->
@@ -150,9 +147,9 @@ cat > "$TEST_ROOT/empty.csproj" <<'EOF'
   </PropertyGroup>
 </Project>
 EOF
-PREVIOUS="$(VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh" "$TEST_ROOT/empty.csproj")"
+PREVIOUS="$(VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh" "$TEST_ROOT/empty.props")"
 [[ -z "$PREVIOUS" ]] || fail "rewrite reports no previous baseline for an empty block (got '$PREVIOUS')"
-grep -q '<PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>' "$TEST_ROOT/empty.csproj" \
+grep -q '<PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>' "$TEST_ROOT/empty.props" \
   || fail "rewrite repopulates an empty block"
 
 expect_failure() {
@@ -163,26 +160,26 @@ expect_failure() {
   fi
 }
 
-cat > "$TEST_ROOT/nomarkers.csproj" <<'EOF'
+cat > "$TEST_ROOT/nomarkers.props" <<'EOF'
 <Project>
   <PropertyGroup />
 </Project>
 EOF
-expect_failure "rewrite rejects a project without markers" \
-  env VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh" "$TEST_ROOT/nomarkers.csproj"
+expect_failure "rewrite rejects a file without markers" \
+  env VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh" "$TEST_ROOT/nomarkers.props"
 
-expect_failure "rewrite rejects a missing project" \
-  env VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh" "$TEST_ROOT/absent.csproj"
+expect_failure "rewrite rejects a missing file" \
+  env VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh" "$TEST_ROOT/absent.props"
 
 expect_failure "rewrite rejects a prerelease version" \
-  env VERSION=0.5.0-beta.1 bash "$ACTION_PATH/rewrite.sh" "$PROJECT_A"
+  env VERSION=0.5.0-beta.1 bash "$ACTION_PATH/rewrite.sh" "$BASELINE_A"
 
-expect_failure "rewrite requires at least one project" \
+expect_failure "rewrite requires at least one file" \
   env VERSION=0.5.0 bash "$ACTION_PATH/rewrite.sh"
 
-# A project that fails validation must be left untouched.
-grep -q '<PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>' "$PROJECT_A" \
-  || fail "a rejected run leaves the project untouched"
+# A file that fails validation must be left untouched.
+grep -q '<PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>' "$BASELINE_A" \
+  || fail "a rejected run leaves the file untouched"
 
 if [[ "$FAILURES" -gt 0 ]]; then
   echo "$FAILURES baseline bump test(s) failed."

--- a/.github/workflows/baseline-bump.yml
+++ b/.github/workflows/baseline-bump.yml
@@ -1,9 +1,9 @@
 name: Bump package validation baseline
 
 # After a stable vX.Y.Z release ships, raise a pull request pinning
-# <PackageValidationBaselineVersion> in the packable projects to that release, so subsequent
-# builds compare the public API against what consumers actually have and fail on an
-# undeclared breaking change.
+# <PackageValidationBaselineVersion> in the shared baseline file to that release, so
+# subsequent builds compare the public API against what consumers actually have and fail on
+# an undeclared breaking change.
 #
 # Prereleases are never tagged and never create a GitHub release, so they never reach here.
 # The version input lets a maintainer re-run the bump against a known good tag if the

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
       - "release/*"
+    # Baseline bump pull requests are validated before merge. Advancing only the comparison
+    # baseline must not publish a new alpha or beta package from the merge commit.
+    paths-ignore:
+      - PackageValidationBaseline.props
   workflow_dispatch:
     inputs:
       release:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,4 +16,5 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)PackageValidationBaseline.props" />
 </Project>

--- a/PackageValidationBaseline.props
+++ b/PackageValidationBaseline.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!-- BEGIN: bot-managed baseline -->
+    <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
+    <!-- END: bot-managed baseline -->
+  </PropertyGroup>
+</Project>

--- a/src/Sigstore/Sigstore.csproj
+++ b/src/Sigstore/Sigstore.csproj
@@ -15,9 +15,6 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <!-- BEGIN: bot-managed baseline -->
-    <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
-    <!-- END: bot-managed baseline -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tuf/Tuf.csproj
+++ b/src/Tuf/Tuf.csproj
@@ -15,9 +15,6 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <!-- BEGIN: bot-managed baseline -->
-    <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
-    <!-- END: bot-managed baseline -->
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Applies the baseline-only push suppression to the active 1.0 servicing branch. Baseline bump pull requests still receive full validation, but merging one will not publish an empty 1.0.x beta package.

This is the release/1.0 counterpart to the main-branch workflow fix.